### PR TITLE
bag_to_pcd: check return code of transformPointCloud()

### DIFF
--- a/pcl_ros/src/tools/bag_to_pcd.cpp
+++ b/pcl_ros/src/tools/bag_to_pcd.cpp
@@ -129,8 +129,13 @@ int
         ++view_it;
         continue;
       }
+
       // Transform it
-      pcl_ros::transformPointCloud ("/base_link", *cloud, cloud_t, tf_listener);
+      if (!pcl_ros::transformPointCloud ("/base_link", *cloud, cloud_t, tf_listener))
+      {
+        ++view_it;
+        continue;
+      }
 
       std::cerr << "Got " << cloud_t.width * cloud_t.height << " data points in frame " << cloud_t.header.frame_id << " with the following fields: " << pcl::getFieldsList (cloud_t) << std::endl;
 


### PR DESCRIPTION
This fixes a bug where bag_to_pcd segfaults because of an ignored 
tf::ExtrapolationException.
