### PR TITLE
Fix a serialization error with point_cloud headers

### DIFF
--- a/pcl_ros/include/pcl_ros/point_cloud.h
+++ b/pcl_ros/include/pcl_ros/point_cloud.h
@@ -213,8 +213,8 @@ namespace ros
       inline static void read(Stream& stream, pcl::PointCloud<T>& m)
       {
         std_msgs::Header header;
-        pcl_conversions::fromPCL(m.header, header);
         stream.next(header);
+        pcl_conversions::toPCL(header, m.header);
         stream.next(m.height);
         stream.next(m.width);
 


### PR DESCRIPTION
@hershwg reported that headers were loosing `frame_id`'s when subscribing with `pcl::PointCloud<T>` type.

He setup an example with a bag file here:

https://github.com/hershwg/point_cloud_frame_test

He also pointed out the error, which this pull request addresses.

Thanks @hershwg!
