### PR TITLE
In VoxelGrid, Assertion `px != 0' failed. 

### DIFF
--- a/pcl_ros/include/pcl_ros/filters/extract_indices.h
+++ b/pcl_ros/include/pcl_ros/filters/extract_indices.h
@@ -66,7 +66,7 @@ namespace pcl_ros
               PointCloud2 &output)
       {
         boost::mutex::scoped_lock lock (mutex_);
-        pcl::PCLPointCloud2::Ptr pcl_input;
+        pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
         pcl_conversions::toPCL(*(input), *(pcl_input));
         impl_.setInputCloud (pcl_input);
         impl_.setIndices (indices);

--- a/pcl_ros/include/pcl_ros/filters/passthrough.h
+++ b/pcl_ros/include/pcl_ros/filters/passthrough.h
@@ -64,7 +64,7 @@ namespace pcl_ros
               PointCloud2 &output)
       {
         boost::mutex::scoped_lock lock (mutex_);
-        pcl::PCLPointCloud2::Ptr pcl_input;
+        pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
         pcl_conversions::toPCL (*(input), *(pcl_input));
         impl_.setInputCloud (pcl_input);
         impl_.setIndices (indices);

--- a/pcl_ros/include/pcl_ros/filters/project_inliers.h
+++ b/pcl_ros/include/pcl_ros/filters/project_inliers.h
@@ -68,11 +68,11 @@ namespace pcl_ros
       filter (const PointCloud2::ConstPtr &input, const IndicesPtr &indices, 
               PointCloud2 &output)
       {
-        pcl::PCLPointCloud2::Ptr pcl_input;
+        pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
         pcl_conversions::toPCL (*(input), *(pcl_input));
         impl_.setInputCloud (pcl_input);
         impl_.setIndices (indices);
-        pcl::ModelCoefficients::Ptr pcl_model;
+        pcl::ModelCoefficients::Ptr pcl_model(new pcl::ModelCoefficients);
         pcl_conversions::toPCL(*(model_), *(pcl_model));
         impl_.setModelCoefficients (pcl_model);
         pcl::PCLPointCloud2 pcl_output;

--- a/pcl_ros/include/pcl_ros/filters/radius_outlier_removal.h
+++ b/pcl_ros/include/pcl_ros/filters/radius_outlier_removal.h
@@ -61,7 +61,7 @@ namespace pcl_ros
       filter (const PointCloud2::ConstPtr &input, const IndicesPtr &indices, 
               PointCloud2 &output)
       {
-        pcl::PCLPointCloud2::Ptr pcl_input;
+        pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
         pcl_conversions::toPCL (*(input), *(pcl_input));
         impl_.setInputCloud (pcl_input);
         impl_.setIndices (indices);

--- a/pcl_ros/include/pcl_ros/filters/statistical_outlier_removal.h
+++ b/pcl_ros/include/pcl_ros/filters/statistical_outlier_removal.h
@@ -58,7 +58,7 @@ namespace pcl_ros
     * \note setFilterFieldName (), setFilterLimits (), and setFilterLimitNegative () are ignored.
     * \author Radu Bogdan Rusu
     */
-  class StatisticalOutlierRemoval : public Filter                                    
+  class StatisticalOutlierRemoval : public Filter
   {
     protected:
       /** \brief Pointer to a dynamic reconfigure service. */
@@ -74,7 +74,7 @@ namespace pcl_ros
               PointCloud2 &output)
       {
         boost::mutex::scoped_lock lock (mutex_);
-        pcl::PCLPointCloud2::Ptr pcl_input;
+        pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
         pcl_conversions::toPCL(*(input), *(pcl_input));
         impl_.setInputCloud (pcl_input);
         impl_.setIndices (indices);

--- a/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
+++ b/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
@@ -58,7 +58,7 @@ pcl_ros::VoxelGrid::filter (const PointCloud2::ConstPtr &input,
                             PointCloud2 &output)
 {
   boost::mutex::scoped_lock lock (mutex_);
-  pcl::PCLPointCloud2::Ptr pcl_input;
+  pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
   pcl_conversions::toPCL (*(input), *(pcl_input));
   impl_.setInputCloud (pcl_input);
   impl_.setIndices (indices);


### PR DESCRIPTION
Hi, I found one issue with the voxel grid class for hydro.

I'm running the voxel grid in nodelet manager as follows:

```
<node pkg="nodelet" type="nodelet" name="voxel_grid" args="load pcl/VoxelGrid sensor_manager" output="screen">
    <remap from="~input" to="/camera/depth/points" />
    <rosparam>
      filter_field_name: z
      filter_limit_min: 0.3
      filter_limit_max: 3
      filter_limit_negative: False
      leaf_size: 0.03
    </rosparam>
  </node>
```

when I tried to echo the output: /voxel_grid/output, the error comes as:

```
nodelet: /usr/include/boost/smart_ptr/shared_ptr.hpp:418: boost::shared_ptr<T>::reference boost::shared_ptr<T>::operator*() const [with T = pcl::PCLPointCloud2; boost::shared_ptr<T>::reference = pcl::PCLPointCloud2&]: Assertion `px != 0' failed.
```

I think it's from the voxel_grip.cpp:

```
pcl_conversions::toPCL (*(input), *(pcl_input));
```

I then modified the declaration of pcl_input to:

```
pcl::PCLPointCloud2::Ptr pcl_input (new pcl::PCLPointCloud2);
```

It works after this change. 

But.... the SACSegmentation nodelet is not working correctly. And I could not solve that problem related to memory leak...

```
*** glibc detected *** /opt/ros/hydro/lib/nodelet/nodelet: free(): invalid pointer: 0xb1f1abc0 ***
```

Can anyone please look into this issue?
Thanks!
