### PR TITLE
package.xml: tuned whitespaces

### DIFF
--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -10,7 +10,7 @@
   </description>
   <author>Open Perception</author>
   <maintainer email="jkammerl@willowgarage.com">Julius Kammerl</maintainer>
-  <license>BSD</license>  
+  <license>BSD</license>
   <url>http://ros.org/wiki/perception_pcl</url>
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
This commit removes trailing whitespaces and makes the line with the license information in the package.xml bitwise match exactly the common license information line in most ROS packages.
The trailing whitespaces were detected when providing a bitbake recipe in the meta-ros project (github.com/bmwcarit/meta-ros). In the recipe, the hash of the license line is declared and is used to check for changes in the license. For this recipe, it was not matching the common one.
A related already merged commit is https://github.com/ros/std_msgs/pull/3 and a related pending commit is https://github.com/ros-perception/pcl_msgs/pull/1.
