### PR TITLE
Use cmake_modules to find eigen on indigo

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 project(pcl_ros)
 
 ## Find system dependencies
+find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen REQUIRED)
 find_package(PCL REQUIRED)

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>cmake_modules</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>nodelet</build_depend>


### PR DESCRIPTION
Should be compatible with hydro, needed for indigo.

See also this [ros answers post](http://answers.ros.org/question/144996/find-eigen-on-os-x/) and the [ros indigo migration guide](http://wiki.ros.org/indigo/Migration#cmake_modules).
