### PR TITLE
Update pcl_nodelets.xml

### DIFF
--- a/pcl_ros/pcl_nodelets.xml
+++ b/pcl_ros/pcl_nodelets.xml
@@ -33,6 +33,7 @@
       in parallel, using the OpenMP standard.
     </description>
   </class>
+</library>
 
 <!-- PCL IO library component -->
 <library path="lib/libpcl_ros_io">


### PR DESCRIPTION
Included missing closing library tag.  This was causing the pcl/Filter nodelets below the missing nodelet tag to not be exported correctly.
