### PR TITLE
pointcloud_to_pcd: Added option for fixed/custom filename

### DIFF
--- a/pcl_ros/tools/pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/pointcloud_to_pcd.cpp
@@ -63,6 +63,7 @@ class PointCloudToPCD
 
   private:
     std::string prefix_;
+    std::string filename_;
     bool binary_;
     bool compressed_;
 
@@ -85,7 +86,14 @@ class PointCloudToPCD
                 pcl::getFieldsList (*cloud).c_str ());
 
       std::stringstream ss;
-      ss << prefix_ << cloud->header.stamp << ".pcd";
+      if (filename_ != "")
+      {
+        ss << filename_ << ".pcd";
+      }
+      else
+      {
+        ss << prefix_ << cloud->header.stamp << ".pcd";
+      }
       ROS_INFO ("Data saved to %s", ss.str ().c_str ());
 
       pcl::PCDWriter writer;
@@ -127,6 +135,7 @@ class PointCloudToPCD
 
       priv_nh.getParam ("binary", binary_);
       priv_nh.getParam ("compressed", compressed_);
+      priv_nh.getParam ("filename", filename_);
       if(binary_)
 	{
 	  if(compressed_)
@@ -142,6 +151,11 @@ class PointCloudToPCD
 	{
 	  ROS_INFO_STREAM ("Saving as binary PCD");
 	}
+
+      if (filename_ != "")
+      {
+        ROS_INFO_STREAM ("Saving to fixed filename: " << filename_);
+      }
 
       cloud_topic_ = "input";
 


### PR DESCRIPTION
This adds the option to specify a custom filename independent of the pointcloud header timestamp (which might be useful in some scenarios where the name of the pointcloud file needs to be used as input somewhere else). It does not make use of the specified prefix. If the file exists, it will be overwritten with new pointcloud data upon receiving a new pointcloud message. [Due to this, this is only/most useful in scenarios where there is a low rate of pointclouds coming in.]

I have not found specific suggestion/guidance on how to structure/format contributions - please advice and I'll change accordingly.

Also, please close if this feature is not of interest.

Thanks for your consideration and a fantastic library and package!
