### PR TITLE
Fixing typo in a ROS_INFO statement

### DIFF
--- a/pcl_ros/tools/pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/pointcloud_to_pcd.cpp
@@ -140,7 +140,7 @@ class PointCloudToPCD
 	}
       else
 	{
-	  ROS_INFO_STREAM ("Saving as binary PCD");
+	  ROS_INFO_STREAM ("Saving as ASCII PCD");
 	}
 
       cloud_topic_ = "input";


### PR DESCRIPTION
Statement was incorrectly informing user that PCD would be saved as binary instead of ASCII.
