### PR TITLE
manually remove dependency on vtkproj from PCL_LIBRARIES

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -5,7 +5,11 @@ project(pcl_ros)
 find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED)
+find_package(PCL 1.7 REQUIRED)
+
+if(NOT "${PCL_LIBRARIES}" STREQUAL "")
+  list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
+endif()
 
 ## Find catkin packages
 find_package(catkin REQUIRED COMPONENTS

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -40,6 +40,8 @@
   <build_depend>tf</build_depend>
   <build_depend>python-vtk</build_depend>
   <build_depend>libvtk-java</build_depend>
+  <!-- libproj-dev needed due to error in vtk6 -->
+  <build_depend>libproj-dev</build_depend>
 
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>eigen</run_depend>


### PR DESCRIPTION
Bit of a horrible hack to fix a link error in pcl_ros in Xenial/Kinetic (#119). If the latest version of vtk6 gets synced into Xenial this should be rejected or removed.
