### PR TITLE
Add missing run_depend on proj

### DIFF
--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -58,6 +58,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>libvtk-java</run_depend>
+  <run_depend>proj</run_depend>
 
   <test_depend>rostest</test_depend>
 


### PR DESCRIPTION
Without this patch, rosdep does not generate a dependency on
libproj-dev. Unless libproj-dev is installed manually, compilation for
projects that depends on pcl_ros will fail with an error like this:

```
No rule to make target '/usr/lib/x86_64-linux-gnu/libproj.so'
```
