### PR TITLE
Remove dependency on vtk/libproj-dev

### DIFF
--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -41,9 +41,6 @@
   <depend>std_msgs</depend>
   <depend>tf</depend>
   <depend>tf2_eigen</depend>
-  <depend>libvtk-java</depend>
-  <!-- libproj-dev needed due to error in vtk6 -->
-  <depend>proj</depend>
 
   <test_depend>rostest</test_depend>
 


### PR DESCRIPTION
These dependencies were introduced in #124 to temporarily fix
missing / wrong dependencies in upstream vtk. This hack is no longer
necessary, since fixed vtk packages have been uploaded to
packages.ros.org (see #124 and ros-infrastructure/reprepro-updater#32).
