### PR TITLE
Fix qt5 widgets

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -6,7 +6,8 @@ find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED)
-
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
+set(QT_LIBRARIES Qt5::Widgets)
 if(NOT "${PCL_LIBRARIES}" STREQUAL "")
   list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
   # FIXME: this causes duplicates and not found error in ubuntu:zesty
@@ -83,7 +84,7 @@ catkin_package(
 
 ## Declare the pcl_ros_tf library
 add_library(pcl_ros_tf src/transforms.cpp)
-target_link_libraries(pcl_ros_tf ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${Eigen3_LIBRARIES} ${PCL_LIBRARIES})
+target_link_libraries(pcl_ros_tf ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${Eigen3_LIBRARIES} ${PCL_LIBRARIES} ${QT_LIBRARIES})
 add_dependencies(pcl_ros_tf pcl_ros_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
 
 ## Nodelets

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -6,8 +6,6 @@ find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED)
-# For debian: https://github.com/ros-perception/perception_pcl/issues/139
-find_package(Qt5Widgets QUIET)
 
 if(NOT "${PCL_LIBRARIES}" STREQUAL "")
   list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -25,6 +25,7 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>genmsg</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
   <build_depend>roslib</build_depend>
 
   <depend>dynamic_reconfigure</depend>


### PR DESCRIPTION
I got pcl_ros to compile on Debian Stretch with the following change. Not ready for merge yet, I need to test on the other platforms to be sure it's not breaking anything.