### PR TITLE
Revert "Add README and travis status badge"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,0 @@
-# perception_pcl
-
-[![Build Status](https://travis-ci.org/ros-perception/perception_pcl.svg)](https://travis-ci.org/ros-perception/perception_pcl)
-
-PCL (Point Cloud Library) ROS interface stack. PCL-ROS is the preferred
-bridge for 3D applications involving n-D Point Clouds and 3D geometry
-processing in ROS.


### PR DESCRIPTION
Reverts ros-perception/perception_pcl#118

The base branch must have been lunar-devel.