### PR TITLE
Remove dependency on vtk/libproj-dev

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(PCL REQUIRED)
 find_package(Qt5Widgets QUIET)
 
 if(NOT "${PCL_LIBRARIES}" STREQUAL "")
-  list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
   # FIXME: this causes duplicates and not found error in ubuntu:zesty
   list(REMOVE_ITEM PCL_LIBRARIES "/usr/lib/libmpi.so")
 endif()

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -42,9 +42,6 @@
   <depend>std_msgs</depend>
   <depend>tf</depend>
   <depend>tf2_eigen</depend>
-  <depend>libvtk-java</depend>
-  <!-- libproj-dev needed due to error in vtk6 -->
-  <depend>proj</depend>
   <!-- qtbase5-dev needed due to error in qt5 -->
   <depend>qtbase5-dev</depend>
 


### PR DESCRIPTION
> These dependencies were introduced in #124 to temporarily fix
> missing / wrong dependencies in upstream vtk. This hack is no longer
> necessary, since fixed vtk packages have been uploaded to
> packages.ros.org (see #124 and ros-infrastructure/reprepro-updater#32).

Close #126