### PR TITLE
Qt5 dependency

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -12,7 +12,6 @@ if(NOT "${PCL_LIBRARIES}" STREQUAL "")
   list(REMOVE_ITEM PCL_LIBRARIES "/usr/lib/libmpi.so")
 
   # For debian: https://github.com/ros-perception/perception_pcl/issues/139
-  list(REMOVE_DUPLICATES PCL_LIBRARIES)
   list(REMOVE_ITEM PCL_LIBRARIES
     "vtkGUISupportQt"
     "vtkGUISupportQtOpenGL"

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -6,13 +6,22 @@ find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED COMPONENTS core io surface)
-# For debian: https://github.com/ros-perception/perception_pcl/issues/139
-find_package(Qt5Widgets QUIET)
 
 if(NOT "${PCL_LIBRARIES}" STREQUAL "")
   # FIXME: this causes duplicates and not found error in ubuntu:zesty
   list(REMOVE_ITEM PCL_LIBRARIES "/usr/lib/libmpi.so")
+
+  # For debian: https://github.com/ros-perception/perception_pcl/issues/139
+  list(REMOVE_DUPLICATES PCL_LIBRARIES)
+  list(REMOVE_ITEM PCL_LIBRARIES
+    "vtkGUISupportQt"
+    "vtkGUISupportQtOpenGL"
+    "vtkGUISupportQtSQL"
+    "vtkGUISupportQtWebkit"
+    "vtkViewsQt"
+    "vtkRenderingQt")
 endif()
+
 
 ## Find catkin packages
 find_package(catkin REQUIRED COMPONENTS

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -22,7 +22,6 @@ if(NOT "${PCL_LIBRARIES}" STREQUAL "")
     "vtkRenderingQt")
 endif()
 
-
 ## Find catkin packages
 find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -5,7 +5,7 @@ project(pcl_ros)
 find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED)
+find_package(PCL REQUIRED COMPONENTS core io surface)
 # For debian: https://github.com/ros-perception/perception_pcl/issues/139
 find_package(Qt5Widgets QUIET)
 

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -42,8 +42,6 @@
   <depend>std_msgs</depend>
   <depend>tf</depend>
   <depend>tf2_eigen</depend>
-  <!-- qtbase5-dev needed due to error in qt5 -->
-  <depend>qtbase5-dev</depend>
 
   <test_depend>rostest</test_depend>
 


### PR DESCRIPTION
@wkentaro @paulbovbel I'm opening this for visibility and share my findings when looking into the Qt dependency issue and am open to discussion to reduce the scope or close it if it's not considered of interest.
This is an alternative to https://github.com/ros-perception/perception_pcl/pull/146

I looked a bit more into this issue #139:
to answer the [comment](https://github.com/ros-perception/perception_pcl/pull/142#issuecomment-298602081):
> I still don't understand why pcl_ros depends on qt..

It is because PCL depends on vtk6 rendering tools including the Qt ones. Given that `pcl_ros` finds **all** PCL_LIBRARIES, as a result, `pcl_ros` libraries link against all vtk libraries used by PCL, including the ones depending on Qt.
To avoid depending and linking against libraries you don't use, it is good practice to `find_package()` only the components that you use. See the [first commit](https://github.com/mikaelarguedas/perception_pcl/commit/f968425079a292c3fc64829150c583bea9af2411) of this PR for a suggestion.

This change would **not** allow to get rid of the Qt5Widgets dependency though because the PCL `io` module exports dependencies on Qt5::Widgets (not sure why :confused:)
Looking a bit further into the libraries reported by the PCL IO module, it looks like several of them use Qt: see https://github.com/mikaelarguedas/perception_pcl/commit/54d94db9ae739f8bc8b81abde1f89b22490ad69a for a list.

As Far A I Understand, Ubuntu knows it is a problem and decided to make `libpcl-dev` [depend on](https://packages.ubuntu.com/zesty/libpcl-dev) `libvtk6-qt-dev` rather than fixing the root of the problem. That is why this problem doesn't appear on Ubuntu but only on debian Stretch ([no dependency on](https://packages.debian.org/stretch/libpcl-dev) `libvtk6-qt-dev`).

Possible solutions: 
 - keep the Qt5Widgets import workaround adding an unused dependency
 - merge this PR that allows to get rid of the dependency on Qt but make the CMake code a bit more complex.

In the meantime, I'll try to find out why even the io module depends on Qt and where to report the issue to get it fixed upstream