### PR TITLE
Inherit NodeletLazy for pipeline with less cpu load

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -76,6 +76,7 @@ catkin_package(
     dynamic_reconfigure
     message_filters
     nodelet
+    nodelet_topic_tools
     pcl_conversions
     pcl_msgs
     rosbag

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -5,7 +5,7 @@ project(pcl_ros)
 find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED COMPONENTS core io surface)
+find_package(PCL REQUIRED COMPONENTS core features filters io surface)
 
 if(NOT "${PCL_LIBRARIES}" STREQUAL "")
   # FIXME: this causes duplicates and not found error in ubuntu:zesty

--- a/pcl_ros/include/pcl_ros/filters/filter.h
+++ b/pcl_ros/include/pcl_ros/filters/filter.h
@@ -114,6 +114,14 @@ namespace pcl_ros
       filter (const PointCloud2::ConstPtr &input, const IndicesPtr &indices, 
               PointCloud2 &output) = 0;
 
+      /** \brief Lazy transport subscribe routine. */
+      virtual void
+      subscribe();
+
+      /** \brief Lazy transport unsubscribe routine. */
+      virtual void
+      unsubscribe();
+
       /** \brief Nodelet initialization routine. */
       virtual void 
       onInit ();

--- a/pcl_ros/include/pcl_ros/pcl_nodelet.h
+++ b/pcl_ros/include/pcl_ros/pcl_nodelet.h
@@ -52,7 +52,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include "pcl_ros/point_cloud.h"
 // ROS Nodelet includes
-#include <nodelet/nodelet.h>
+#include <nodelet_topic_tools/nodelet_lazy.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>
@@ -69,7 +69,7 @@ namespace pcl_ros
   ////////////////////////////////////////////////////////////////////////////////////////////
   ////////////////////////////////////////////////////////////////////////////////////////////
   /** \brief @b PCLNodelet represents the base PCL Nodelet class. All PCL nodelets should inherit from this class. */
-  class PCLNodelet : public nodelet::Nodelet
+  class PCLNodelet : public nodelet_topic_tools::NodeletLazy
   {
     public:
       typedef sensor_msgs::PointCloud2 PointCloud2;
@@ -94,9 +94,6 @@ namespace pcl_ros
                       max_queue_size_ (3), approximate_sync_ (false) {};
 
     protected:
-      /** \brief The ROS NodeHandle used for parameters, publish/subscribe, etc. */
-      boost::shared_ptr<ros::NodeHandle> pnh_;
-
       /** \brief Set to true if point indices are used.
        *
        * When receiving a point cloud, if use_indices_ is false, the entire
@@ -197,12 +194,16 @@ namespace pcl_ros
         return (true);
       }
 
+      /** \brief Lazy transport subscribe/unsubscribe routine. It is optional for backward compatibility. */
+      virtual void subscribe () {}
+      virtual void unsubscribe () {}
+
       /** \brief Nodelet initialization routine. Reads in global parameters used by all nodelets. */
       virtual void
       onInit ()
       {
-        pnh_.reset (new ros::NodeHandle (getMTPrivateNodeHandle ()));
-        
+        nodelet_topic_tools::NodeletLazy::onInit();
+
         // Parameters that we care about only at startup
         pnh_->getParam ("max_queue_size", max_queue_size_);
         


### PR DESCRIPTION
## Why?

Checking number of subscribers in the callback is not enough to reduce cpu load with nodelet pipeline. 
If a leaf nodelet subscribes the parent node's topic, the parent node processes in the callback because `pub_output.getNumSubscribers() == 1`.