### PR TITLE
pcl_ros: use nodelet_topic_tools::NodeletLazy

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -5,7 +5,7 @@ project(pcl_ros)
 find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED COMPONENTS core io surface)
+find_package(PCL REQUIRED)
 
 if(NOT "${PCL_LIBRARIES}" STREQUAL "")
   # FIXME: this causes duplicates and not found error in ubuntu:zesty

--- a/pcl_ros/include/pcl_ros/features/boundary.h
+++ b/pcl_ros/include/pcl_ros/features/boundary.h
@@ -65,7 +65,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/feature.h
+++ b/pcl_ros/include/pcl_ros/features/feature.h
@@ -165,6 +165,14 @@ namespace pcl_ros
       /** \brief Nodelet initialization routine. */
       virtual void onInit ();
 
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
+
       /** \brief Input point cloud callback. Used when \a use_indices and \a use_surface are set.
         * \param cloud the pointer to the input point cloud
         * \param cloud_surface the pointer to the surface point cloud
@@ -223,6 +231,14 @@ namespace pcl_ros
 
       /** \brief Nodelet initialization routine. */
       virtual void onInit ();
+
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
 
       /** \brief Input point cloud callback. Used when \a use_indices and \a use_surface are set.
         * \param cloud the pointer to the input point cloud

--- a/pcl_ros/include/pcl_ros/features/fpfh.h
+++ b/pcl_ros/include/pcl_ros/features/fpfh.h
@@ -77,7 +77,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/fpfh_omp.h
+++ b/pcl_ros/include/pcl_ros/features/fpfh_omp.h
@@ -74,7 +74,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/moment_invariants.h
+++ b/pcl_ros/include/pcl_ros/features/moment_invariants.h
@@ -61,7 +61,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/normal_3d.h
+++ b/pcl_ros/include/pcl_ros/features/normal_3d.h
@@ -63,7 +63,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/normal_3d_omp.h
+++ b/pcl_ros/include/pcl_ros/features/normal_3d_omp.h
@@ -59,7 +59,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/normal_3d_tbb.h
+++ b/pcl_ros/include/pcl_ros/features/normal_3d_tbb.h
@@ -62,7 +62,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloud> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloud> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/pfh.h
+++ b/pcl_ros/include/pcl_ros/features/pfh.h
@@ -77,7 +77,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/principal_curvatures.h
+++ b/pcl_ros/include/pcl_ros/features/principal_curvatures.h
@@ -63,7 +63,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/shot.h
+++ b/pcl_ros/include/pcl_ros/features/shot.h
@@ -57,7 +57,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/shot_omp.h
+++ b/pcl_ros/include/pcl_ros/features/shot_omp.h
@@ -56,7 +56,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/features/vfh.h
+++ b/pcl_ros/include/pcl_ros/features/vfh.h
@@ -62,7 +62,7 @@ namespace pcl_ros
       childInit (ros::NodeHandle &nh)
       {
         // Create the output publisher
-        pub_output_ = nh.advertise<PointCloudOut> ("output", max_queue_size_);
+        pub_output_ = advertise<PointCloudOut> (nh, "output", max_queue_size_);
         return (true);
       }
 

--- a/pcl_ros/include/pcl_ros/filters/filter.h
+++ b/pcl_ros/include/pcl_ros/filters/filter.h
@@ -133,6 +133,14 @@ namespace pcl_ros
       boost::shared_ptr<message_filters::Synchronizer<sync_policies::ExactTime<PointCloud2, PointIndices> > >       sync_input_indices_e_;
       boost::shared_ptr<message_filters::Synchronizer<sync_policies::ApproximateTime<PointCloud2, PointIndices> > > sync_input_indices_a_;
 
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
+
       /** \brief Dynamic reconfigure service callback. */
       virtual void 
       config_callback (pcl_ros::FilterConfig &config, uint32_t level);

--- a/pcl_ros/include/pcl_ros/filters/project_inliers.h
+++ b/pcl_ros/include/pcl_ros/filters/project_inliers.h
@@ -97,6 +97,14 @@ namespace pcl_ros
       virtual void 
       onInit ();
 
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
+
       /** \brief PointCloud2 + Indices + Model data callback. */
       void 
       input_indices_model_callback (const PointCloud2::ConstPtr &cloud, 

--- a/pcl_ros/include/pcl_ros/pcl_nodelet.h
+++ b/pcl_ros/include/pcl_ros/pcl_nodelet.h
@@ -52,7 +52,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include "pcl_ros/point_cloud.h"
 // ROS Nodelet includes
-#include <nodelet/nodelet.h>
+#include <nodelet_topic_tools/nodelet_lazy.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/exact_time.h>
@@ -69,7 +69,7 @@ namespace pcl_ros
   ////////////////////////////////////////////////////////////////////////////////////////////
   ////////////////////////////////////////////////////////////////////////////////////////////
   /** \brief @b PCLNodelet represents the base PCL Nodelet class. All PCL nodelets should inherit from this class. */
-  class PCLNodelet : public nodelet::Nodelet
+  class PCLNodelet : public nodelet_topic_tools::NodeletLazy
   {
     public:
       typedef sensor_msgs::PointCloud2 PointCloud2;
@@ -94,9 +94,6 @@ namespace pcl_ros
                       max_queue_size_ (3), approximate_sync_ (false) {};
 
     protected:
-      /** \brief The ROS NodeHandle used for parameters, publish/subscribe, etc. */
-      boost::shared_ptr<ros::NodeHandle> pnh_;
-
       /** \brief Set to true if point indices are used.
        *
        * When receiving a point cloud, if use_indices_ is false, the entire
@@ -201,7 +198,7 @@ namespace pcl_ros
       virtual void
       onInit ()
       {
-        pnh_.reset (new ros::NodeHandle (getMTPrivateNodeHandle ()));
+        nodelet_topic_tools::NodeletLazy::onInit();
         
         // Parameters that we care about only at startup
         pnh_->getParam ("max_queue_size", max_queue_size_);
@@ -222,6 +219,12 @@ namespace pcl_ros
             (latched_indices_) ? "true" : "false", 
             max_queue_size_);
       }
+
+    /** \brief Callback on subscription. Inherited from nodelet_topic_tools::NodeletLazy. */
+    virtual void subscribe() {};
+
+    /** \brief Callback on unsubscription. Inherited from nodelet_topic_tools::NodeletLazy. */
+    virtual void unsubscribe() {};
 
     public:
       EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/pcl_ros/include/pcl_ros/segmentation/extract_clusters.h
+++ b/pcl_ros/include/pcl_ros/segmentation/extract_clusters.h
@@ -74,6 +74,14 @@ namespace pcl_ros
       /** \brief Nodelet initialization routine. */
       void onInit ();
 
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
+
       /** \brief Dynamic reconfigure callback
         * \param config the config object
         * \param level the dynamic reconfigure level

--- a/pcl_ros/include/pcl_ros/segmentation/extract_polygonal_prism_data.h
+++ b/pcl_ros/include/pcl_ros/segmentation/extract_polygonal_prism_data.h
@@ -100,6 +100,14 @@ namespace pcl_ros
        /** \brief Nodelet initialization routine. */
       void onInit ();
 
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
+
       /** \brief Dynamic reconfigure callback
         * \param config the config object
         * \param level the dynamic reconfigure level

--- a/pcl_ros/include/pcl_ros/segmentation/sac_segmentation.h
+++ b/pcl_ros/include/pcl_ros/segmentation/sac_segmentation.h
@@ -117,6 +117,14 @@ namespace pcl_ros
       /** \brief Nodelet initialization routine. */
       virtual void onInit ();
 
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
+
       /** \brief Dynamic reconfigure callback
         * \param config the config object
         * \param level the dynamic reconfigure level

--- a/pcl_ros/include/pcl_ros/segmentation/segment_differences.h
+++ b/pcl_ros/include/pcl_ros/segmentation/segment_differences.h
@@ -81,6 +81,14 @@ namespace pcl_ros
       /** \brief Nodelet initialization routine. */
       void onInit ();
 
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
+
       /** \brief Dynamic reconfigure callback
         * \param config the config object
         * \param level the dynamic reconfigure level

--- a/pcl_ros/include/pcl_ros/surface/convex_hull.h
+++ b/pcl_ros/include/pcl_ros/surface/convex_hull.h
@@ -63,6 +63,14 @@ namespace pcl_ros
       /** \brief Nodelet initialization routine. */
       virtual void onInit ();
 
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
+
       /** \brief Input point cloud callback.
         * \param cloud the pointer to the input point cloud
         * \param indices the pointer to the input point cloud indices

--- a/pcl_ros/include/pcl_ros/surface/moving_least_squares.h
+++ b/pcl_ros/include/pcl_ros/surface/moving_least_squares.h
@@ -115,6 +115,14 @@ namespace pcl_ros
       /** \brief Nodelet initialization routine. */
       virtual void onInit ();
 
+      /** \brief Callback on subscription. */
+      virtual void
+      subscribe();
+
+      /** \brief Callback on unsubscription */
+      virtual void
+      unsubscribe();
+
       /** \brief Input point cloud callback.
         * \param cloud the pointer to the input point cloud
         * \param indices the pointer to the input point cloud indices

--- a/pcl_ros/src/pcl_ros/features/feature.cpp
+++ b/pcl_ros/src/pcl_ros/features/feature.cpp
@@ -85,6 +85,21 @@ pcl_ros::Feature::onInit ()
   dynamic_reconfigure::Server<FeatureConfig>::CallbackType f = boost::bind (&Feature::config_callback, this, _1, _2);
   srv_->setCallback (f);
 
+  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
+                 " - use_surface    : %s\n"
+                 " - k_search       : %d\n"
+                 " - radius_search  : %f\n"
+                 " - spatial_locator: %d",
+                getName ().c_str (),
+                (use_surface_) ? "true" : "false", k_, search_radius_, spatial_locator_type_);
+
+  onInitPostProcess();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::Feature::subscribe()
+{
   // If we're supposed to look for PointIndices (indices) or PointCloud (surface) messages
   if (use_indices_ || use_surface_)
   {
@@ -138,14 +153,26 @@ pcl_ros::Feature::onInit ()
   else
     // Subscribe in an old fashion to input only (no filters)
     sub_input_ = pnh_->subscribe<PointCloudIn> ("input", max_queue_size_,  bind (&Feature::input_surface_indices_callback, this, _1, PointCloudInConstPtr (), PointIndicesConstPtr ()));
+}
 
-  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
-                 " - use_surface    : %s\n"
-                 " - k_search       : %d\n"
-                 " - radius_search  : %f\n"
-                 " - spatial_locator: %d",
-                getName ().c_str (),
-                (use_surface_) ? "true" : "false", k_, search_radius_, spatial_locator_type_);
+////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::Feature::unsubscribe()
+{
+  if (use_indices_ || use_surface_)
+  {
+    sub_input_filter_.unsubscribe();
+    if (use_indices_)
+    {
+      sub_indices_filter_.unsubscribe();
+      if (use_surface_)
+        sub_surface_filter_.unsubscribe();
+    }
+    else
+      sub_surface_filter_.unsubscribe();
+  }
+  else
+    sub_input_.shutdown();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -169,10 +196,6 @@ void
 pcl_ros::Feature::input_surface_indices_callback (const PointCloudInConstPtr &cloud, 
     const PointCloudInConstPtr &cloud_surface, const PointIndicesConstPtr &indices)
 {
-  // No subscribers, no work
-  if (pub_output_.getNumSubscribers () <= 0)
-    return;
-
   // If cloud is given, check if it's valid
   if (!isValid (cloud))
   {
@@ -273,13 +296,28 @@ pcl_ros::FeatureFromNormals::onInit ()
   // ---[ Optional parameters
   pnh_->getParam ("use_surface", use_surface_);
 
-  sub_input_filter_.subscribe (*pnh_, "input", max_queue_size_);
-  sub_normals_filter_.subscribe (*pnh_, "normals", max_queue_size_);
-
   // Enable the dynamic reconfigure service
   srv_ = boost::make_shared<dynamic_reconfigure::Server<FeatureConfig> > (*pnh_);
   dynamic_reconfigure::Server<FeatureConfig>::CallbackType f = boost::bind (&FeatureFromNormals::config_callback, this, _1, _2);
   srv_->setCallback (f);
+
+  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
+                 " - use_surface    : %s\n"
+                 " - k_search       : %d\n"
+                 " - radius_search  : %f\n"
+                 " - spatial_locator: %d",
+                getName ().c_str (),
+                 (use_surface_) ? "true" : "false", k_, search_radius_, spatial_locator_type_);
+
+  onInitPostProcess();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::FeatureFromNormals::subscribe()
+{
+  sub_input_filter_.subscribe (*pnh_, "input", max_queue_size_);
+  sub_normals_filter_.subscribe (*pnh_, "normals", max_queue_size_);
 
   // Create the objects here
   if (approximate_sync_)
@@ -342,13 +380,26 @@ pcl_ros::FeatureFromNormals::onInit ()
   else
     sync_input_normals_surface_indices_e_->registerCallback (bind (&FeatureFromNormals::input_normals_surface_indices_callback, this, _1, _2, _3, _4));
 
-  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
-                 " - use_surface    : %s\n"
-                 " - k_search       : %d\n"
-                 " - radius_search  : %f\n"
-                 " - spatial_locator: %d",
-                getName ().c_str (),
-                 (use_surface_) ? "true" : "false", k_, search_radius_, spatial_locator_type_);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::FeatureFromNormals::unsubscribe()
+{
+  sub_input_filter_.unsubscribe();
+  sub_normals_filter_.unsubscribe();
+
+  if (use_indices_ || use_surface_)
+  {
+    if (use_indices_)
+    {
+      sub_indices_filter_.unsubscribe();
+      if (use_surface_)
+        sub_surface_filter_.unsubscribe();
+    }
+    else
+      sub_surface_filter_.unsubscribe();
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -117,7 +117,7 @@ pcl_ros::Filter::onInit ()
     return;
   }
 
-  pub_output_ = pnh_->advertise<PointCloud2> ("output", max_queue_size_);
+  pub_output_ = advertise<PointCloud2> (*pnh_, "output", max_queue_size_);
 
   // Enable the dynamic reconfigure service
   if (!has_service)
@@ -127,6 +127,15 @@ pcl_ros::Filter::onInit ()
     srv_->setCallback (f);
   }
 
+  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created.", getName ().c_str ());
+
+  onInitPostProcess();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::Filter::subscribe()
+{
   // If we're supposed to look for PointIndices (indices)
   if (use_indices_)
   {
@@ -150,8 +159,19 @@ pcl_ros::Filter::onInit ()
   else
     // Subscribe in an old fashion to input only (no filters)
     sub_input_ = pnh_->subscribe<sensor_msgs::PointCloud2> ("input", max_queue_size_,  bind (&Filter::input_indices_callback, this, _1, pcl_msgs::PointIndicesConstPtr ()));
+}
 
-  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created.", getName ().c_str ());
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::Filter::unsubscribe()
+{
+  if (use_indices_)
+  {
+    sub_input_filter_.unsubscribe();
+    sub_indices_filter_.unsubscribe();
+  }
+  else
+    sub_input_.shutdown();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/filters/project_inliers.cpp
+++ b/pcl_ros/src/pcl_ros/filters/project_inliers.cpp
@@ -65,8 +65,27 @@ pcl_ros::ProjectInliers::onInit ()
   pnh_->getParam ("copy_all_data", copy_all_data);
   pnh_->getParam ("copy_all_fields", copy_all_fields);
 
-  pub_output_ = pnh_->advertise<PointCloud2> ("output", max_queue_size_);
+  pub_output_ = advertise<PointCloud2> (*pnh_, "output", max_queue_size_);
 
+  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
+                 " - model_type      : %d\n"
+                 " - copy_all_data   : %s\n"
+                 " - copy_all_fields : %s",
+                 getName ().c_str (),
+                 model_type, (copy_all_data) ? "true" : "false", (copy_all_fields) ? "true" : "false");
+
+  // Set given parameters here
+  impl_.setModelType (model_type);
+  impl_.setCopyAllFields (copy_all_fields);
+  impl_.setCopyAllData (copy_all_data);
+
+  onInitPostProcess();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::ProjectInliers::subscribe()
+{
   // Subscribe to the input using a filter
   sub_input_filter_.subscribe (*pnh_, "input", max_queue_size_);
 
@@ -91,18 +110,15 @@ pcl_ros::ProjectInliers::onInit ()
     sync_input_indices_model_e_->connectInput (sub_input_filter_, sub_indices_filter_, sub_model_);
     sync_input_indices_model_e_->registerCallback (bind (&ProjectInliers::input_indices_model_callback, this, _1, _2, _3));
   }
-  
-  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
-                 " - model_type      : %d\n"
-                 " - copy_all_data   : %s\n"
-                 " - copy_all_fields : %s",
-                 getName ().c_str (),
-                 model_type, (copy_all_data) ? "true" : "false", (copy_all_fields) ? "true" : "false");
+}
 
-  // Set given parameters here
-  impl_.setModelType (model_type);
-  impl_.setCopyAllFields (copy_all_fields);
-  impl_.setCopyAllData (copy_all_data);
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::ProjectInliers::unsubscribe()
+{
+  sub_input_filter_.unsubscribe();
+  sub_indices_filter_.unsubscribe();
+  sub_model_.unsubscribe();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/segmentation/extract_clusters.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/extract_clusters.cpp
@@ -71,15 +71,33 @@ pcl_ros::EuclideanClusterExtraction::onInit ()
   pnh_->getParam ("publish_indices", publish_indices_);
 
   if (publish_indices_)
-    pub_output_ = pnh_->advertise<PointIndices> ("output", max_queue_size_);
+    pub_output_ = advertise<PointIndices> (*pnh_, "output", max_queue_size_);
   else
-    pub_output_ = pnh_->advertise<PointCloud> ("output", max_queue_size_);
+    pub_output_ = advertise<PointCloud> (*pnh_, "output", max_queue_size_);
 
   // Enable the dynamic reconfigure service
   srv_ = boost::make_shared <dynamic_reconfigure::Server<EuclideanClusterExtractionConfig> > (*pnh_);
   dynamic_reconfigure::Server<EuclideanClusterExtractionConfig>::CallbackType f =  boost::bind (&EuclideanClusterExtraction::config_callback, this, _1, _2);
   srv_->setCallback (f);
 
+  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
+                 " - max_queue_size    : %d\n"
+                 " - use_indices       : %s\n"
+                 " - cluster_tolerance : %f\n",
+                 getName ().c_str (),
+                 max_queue_size_,
+                 (use_indices_) ? "true" : "false", cluster_tolerance);
+
+  // Set given parameters here
+  impl_.setClusterTolerance (cluster_tolerance);
+
+  onInitPostProcess();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::EuclideanClusterExtraction::subscribe()
+{
   // If we're supposed to look for PointIndices (indices)
   if (use_indices_)
   {
@@ -103,17 +121,19 @@ pcl_ros::EuclideanClusterExtraction::onInit ()
   else
     // Subscribe in an old fashion to input only (no filters)
     sub_input_ = pnh_->subscribe<PointCloud> ("input", max_queue_size_, bind (&EuclideanClusterExtraction::input_indices_callback, this, _1, PointIndicesConstPtr ()));
+}
 
-  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
-                 " - max_queue_size    : %d\n"
-                 " - use_indices       : %s\n"
-                 " - cluster_tolerance : %f\n",
-                 getName ().c_str (),
-                 max_queue_size_,
-                 (use_indices_) ? "true" : "false", cluster_tolerance);
-
-  // Set given parameters here
-  impl_.setClusterTolerance (cluster_tolerance);
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::EuclideanClusterExtraction::unsubscribe()
+{
+  if (use_indices_)
+  {
+    sub_input_filter_.unsubscribe();
+    sub_indices_filter_.unsubscribe();
+  }
+  else
+    sub_input_.shutdown();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/segmentation/sac_segmentation.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/sac_segmentation.cpp
@@ -50,54 +50,9 @@ pcl_ros::SACSegmentation::onInit ()
   // Call the super onInit ()
   PCLNodelet::onInit ();
 
-  // If we're supposed to look for PointIndices (indices)
-  if (use_indices_)
-  {
-    // Subscribe to the input using a filter
-    sub_input_filter_.subscribe (*pnh_, "input", max_queue_size_);
-    sub_indices_filter_.subscribe (*pnh_, "indices", max_queue_size_);
-
-    // when "use_indices" is set to true, and "latched_indices" is set to true,
-    // we'll subscribe and get a separate callback for PointIndices that will 
-    // save the indices internally, and a PointCloud + PointIndices callback 
-    // will take care of meshing the new PointClouds with the old saved indices. 
-    if (latched_indices_)
-    {
-      // Subscribe to a callback that saves the indices
-      sub_indices_filter_.registerCallback (bind (&SACSegmentation::indices_callback, this, _1));
-      // Subscribe to a callback that sets the header of the saved indices to the cloud header
-      sub_input_filter_.registerCallback (bind (&SACSegmentation::input_callback, this, _1));
-
-      // Synchronize the two topics. No need for an approximate synchronizer here, as we'll
-      // match the timestamps exactly
-      sync_input_indices_e_ = boost::make_shared <message_filters::Synchronizer<sync_policies::ExactTime<PointCloud, PointIndices> > > (max_queue_size_);
-      sync_input_indices_e_->connectInput (sub_input_filter_, nf_pi_);
-      sync_input_indices_e_->registerCallback (bind (&SACSegmentation::input_indices_callback, this, _1, _2));
-    }
-    // "latched_indices" not set, proceed with regular <input,indices> pairs
-    else
-    {
-      if (approximate_sync_)
-      {
-        sync_input_indices_a_ = boost::make_shared <message_filters::Synchronizer<sync_policies::ApproximateTime<PointCloud, PointIndices> > > (max_queue_size_);
-        sync_input_indices_a_->connectInput (sub_input_filter_, sub_indices_filter_);
-        sync_input_indices_a_->registerCallback (bind (&SACSegmentation::input_indices_callback, this, _1, _2));
-      }
-      else
-      {
-        sync_input_indices_e_ = boost::make_shared <message_filters::Synchronizer<sync_policies::ExactTime<PointCloud, PointIndices> > > (max_queue_size_);
-        sync_input_indices_e_->connectInput (sub_input_filter_, sub_indices_filter_);
-        sync_input_indices_e_->registerCallback (bind (&SACSegmentation::input_indices_callback, this, _1, _2));
-      }
-    }
-  }
-  else
-    // Subscribe in an old fashion to input only (no filters)
-    sub_input_ = pnh_->subscribe<PointCloud> ("input", max_queue_size_,  bind (&SACSegmentation::input_indices_callback, this, _1, PointIndicesConstPtr ()));
-
   // Advertise the output topics
-  pub_indices_ = pnh_->advertise<PointIndices> ("inliers", max_queue_size_);
-  pub_model_   = pnh_->advertise<ModelCoefficients> ("model", max_queue_size_);
+  pub_indices_ = advertise<PointIndices> (*pnh_, "inliers", max_queue_size_);
+  pub_model_   = advertise<ModelCoefficients> (*pnh_, "model", max_queue_size_);
 
   // ---[ Mandatory parameters
   int model_type;
@@ -167,6 +122,71 @@ pcl_ros::SACSegmentation::onInit ()
   impl_.setModelType (model_type);
   impl_.setMethodType (method_type);
   impl_.setAxis (axis);
+
+  onInitPostProcess();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::SACSegmentation::subscribe ()
+{
+  // If we're supposed to look for PointIndices (indices)
+  if (use_indices_)
+  {
+    // Subscribe to the input using a filter
+    sub_input_filter_.subscribe (*pnh_, "input", max_queue_size_);
+    sub_indices_filter_.subscribe (*pnh_, "indices", max_queue_size_);
+
+    // when "use_indices" is set to true, and "latched_indices" is set to true,
+    // we'll subscribe and get a separate callback for PointIndices that will 
+    // save the indices internally, and a PointCloud + PointIndices callback 
+    // will take care of meshing the new PointClouds with the old saved indices. 
+    if (latched_indices_)
+    {
+      // Subscribe to a callback that saves the indices
+      sub_indices_filter_.registerCallback (bind (&SACSegmentation::indices_callback, this, _1));
+      // Subscribe to a callback that sets the header of the saved indices to the cloud header
+      sub_input_filter_.registerCallback (bind (&SACSegmentation::input_callback, this, _1));
+
+      // Synchronize the two topics. No need for an approximate synchronizer here, as we'll
+      // match the timestamps exactly
+      sync_input_indices_e_ = boost::make_shared <message_filters::Synchronizer<sync_policies::ExactTime<PointCloud, PointIndices> > > (max_queue_size_);
+      sync_input_indices_e_->connectInput (sub_input_filter_, nf_pi_);
+      sync_input_indices_e_->registerCallback (bind (&SACSegmentation::input_indices_callback, this, _1, _2));
+    }
+    // "latched_indices" not set, proceed with regular <input,indices> pairs
+    else
+    {
+      if (approximate_sync_)
+      {
+        sync_input_indices_a_ = boost::make_shared <message_filters::Synchronizer<sync_policies::ApproximateTime<PointCloud, PointIndices> > > (max_queue_size_);
+        sync_input_indices_a_->connectInput (sub_input_filter_, sub_indices_filter_);
+        sync_input_indices_a_->registerCallback (bind (&SACSegmentation::input_indices_callback, this, _1, _2));
+      }
+      else
+      {
+        sync_input_indices_e_ = boost::make_shared <message_filters::Synchronizer<sync_policies::ExactTime<PointCloud, PointIndices> > > (max_queue_size_);
+        sync_input_indices_e_->connectInput (sub_input_filter_, sub_indices_filter_);
+        sync_input_indices_e_->registerCallback (bind (&SACSegmentation::input_indices_callback, this, _1, _2));
+      }
+    }
+  }
+  else
+    // Subscribe in an old fashion to input only (no filters)
+    sub_input_ = pnh_->subscribe<PointCloud> ("input", max_queue_size_,  bind (&SACSegmentation::input_indices_callback, this, _1, PointIndicesConstPtr ()));
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::SACSegmentation::unsubscribe ()
+{
+  if (use_indices_)
+  {
+    sub_input_filter_.unsubscribe();
+    sub_indices_filter_.unsubscribe();
+  }
+  else
+    sub_input_.shutdown();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/segmentation/segment_differences.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/segment_differences.cpp
@@ -46,16 +46,28 @@ pcl_ros::SegmentDifferences::onInit ()
   // Call the super onInit ()
   PCLNodelet::onInit ();
 
-  pub_output_ = pnh_->advertise<PointCloud> ("output", max_queue_size_);
-
-  // Subscribe to the input using a filter
-  sub_input_filter_.subscribe (*pnh_, "input", max_queue_size_);
-  sub_target_filter_.subscribe (*pnh_, "target", max_queue_size_);
+  pub_output_ = advertise<PointCloud> (*pnh_, "output", max_queue_size_);
 
   // Enable the dynamic reconfigure service
   srv_ = boost::make_shared <dynamic_reconfigure::Server<SegmentDifferencesConfig> > (*pnh_);
   dynamic_reconfigure::Server<SegmentDifferencesConfig>::CallbackType f =  boost::bind (&SegmentDifferences::config_callback, this, _1, _2);
   srv_->setCallback (f);
+
+  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
+                 " - max_queue_size    : %d",
+                 getName ().c_str (),
+                 max_queue_size_);
+
+  onInitPostProcess();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::SegmentDifferences::subscribe()
+{
+  // Subscribe to the input using a filter
+  sub_input_filter_.subscribe (*pnh_, "input", max_queue_size_);
+  sub_target_filter_.subscribe (*pnh_, "target", max_queue_size_);
 
   if (approximate_sync_)
   {
@@ -69,11 +81,14 @@ pcl_ros::SegmentDifferences::onInit ()
     sync_input_target_e_->connectInput (sub_input_filter_, sub_target_filter_);
     sync_input_target_e_->registerCallback (bind (&SegmentDifferences::input_target_callback, this, _1, _2));
   }
+}
 
-  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
-                 " - max_queue_size    : %d",
-                 getName ().c_str (),
-                 max_queue_size_);
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::SegmentDifferences::unsubscribe()
+{
+  sub_input_filter_.unsubscribe();
+  sub_target_filter_.unsubscribe();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
+++ b/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
@@ -45,8 +45,8 @@ pcl_ros::MovingLeastSquares::onInit ()
   PCLNodelet::onInit ();
   
   //ros::NodeHandle private_nh = getMTPrivateNodeHandle ();
-  pub_output_ = pnh_->advertise<PointCloudIn> ("output", max_queue_size_);
-  pub_normals_ = pnh_->advertise<NormalCloudOut> ("normals", max_queue_size_);
+  pub_output_ = advertise<PointCloudIn> (*pnh_, "output", max_queue_size_);
+  pub_normals_ = advertise<NormalCloudOut> (*pnh_, "normals", max_queue_size_);
   
   //if (!pnh_->getParam ("k_search", k_) && !pnh_->getParam ("search_radius", search_radius_))  
   if (!pnh_->getParam ("search_radius", search_radius_))
@@ -69,6 +69,18 @@ pcl_ros::MovingLeastSquares::onInit ()
   // ---[ Optional parameters
   pnh_->getParam ("use_indices", use_indices_);
 
+  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
+                 " - use_indices    : %s",
+                 getName ().c_str (), 
+                 (use_indices_) ? "true" : "false");
+
+  onInitPostProcess();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::MovingLeastSquares::subscribe()
+{
   // If we're supposed to look for PointIndices (indices)
   if (use_indices_)
   {
@@ -95,12 +107,19 @@ pcl_ros::MovingLeastSquares::onInit ()
   else
     // Subscribe in an old fashion to input only (no filters)
     sub_input_ = pnh_->subscribe<PointCloudIn> ("input", 1,  bind (&MovingLeastSquares::input_indices_callback, this, _1, PointIndicesConstPtr ()));
+}
 
-
-  NODELET_DEBUG ("[%s::onInit] Nodelet successfully created with the following parameters:\n"
-                 " - use_indices    : %s",
-                 getName ().c_str (), 
-                 (use_indices_) ? "true" : "false");
+//////////////////////////////////////////////////////////////////////////////////////////////
+void
+pcl_ros::MovingLeastSquares::unsubscribe()
+{
+  if (use_indices_)
+  {
+    sub_input_filter_.unsubscribe();
+    sub_indices_filter_.unsubscribe();
+  }
+  else
+    sub_input_.shutdown();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Yet another implementation of #153.

In this pull request, `pcl_ros::PCLNodelet` inherits `nodelet_topic_tools::NodeletLazy` that provides lazy subscription of input topics.
Each nodes now only subscribe topics only they have subscribers and does not consume computational resource if no subscriber exists.