### PR TITLE
Drop yakkety from CI: Yakkety went EOL in July

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   matrix:
     - DOCKER_IMAGE=debian:stretch
     - DOCKER_IMAGE=ubuntu:xenial
-    - DOCKER_IMAGE=ubuntu:yakkety
     - DOCKER_IMAGE=ubuntu:zesty
 # Install system dependencies, namely ROS.
 before_install:


### PR DESCRIPTION
Close https://github.com/ros-perception/perception_pcl/issues/166

https://discourse.ros.org/t/suspension-of-debian-packaging-for-eol-ubuntu-yakkety/2444