### PR TITLE
Drop zesty from CI: zesty went EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   matrix:
     - DOCKER_IMAGE=debian:stretch
     - DOCKER_IMAGE=ubuntu:xenial
-    - DOCKER_IMAGE=ubuntu:zesty
 # Install system dependencies, namely ROS.
 before_install:
   # Define some config vars.


### PR DESCRIPTION
https://github.com/ros/rosdistro/blob/03f2bb4fd0367e1e706cde0745fd52ba52afea74/lunar/distribution.yaml#L11


To fix the test on travis.

https://travis-ci.org/ros-perception/perception_pcl/builds/359449493