### PR TITLE
back to find_package(PCL ..) section to original code in 1.4.1

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -5,7 +5,7 @@ project(pcl_ros)
 find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED COMPONENTS core features filters io segmentation surface)
+find_package(PCL 1.7 REQUIRED)
 
 if(NOT "${PCL_LIBRARIES}" STREQUAL "")
   # For debian: https://github.com/ros-perception/perception_pcl/issues/139


### PR DESCRIPTION
Since 1.4.2, due to the code is introduced in https://github.com/ros-perception/perception_pcl/pull/151, it removes `libpcl_visualization` and/or `libpcl_recognitoin` from `pcl_ros_LIBRARIES` and cause regression (ex. https://github.com/jsk-ros-pkg/jsk_recognition/issues/2259) 
Hope we should have same behavior as 1.4.1 in at least kinetic.

As for a lunar, I do not sure what should we do, but at least, I hope you'll provide all PCL components to the downstream packages
```
find_package(PCL REQUIRED COMPONENTS common
kdtree
octree
search
io
sample_consensus
filters
features
segmentation
surface
registration
recognition
keypoints
visualization
people
outofcore
tracking
)
```