### PR TITLE
Refactor CMakeLists.txt and package.xml

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 ## Find catkin packages
 find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
+  message_filters
   nodelet
   nodelet_topic_tools
   pcl_conversions

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -21,7 +21,6 @@ endif()
 ## Find catkin packages
 find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
-  genmsg
   nodelet
   nodelet_topic_tools
   pcl_conversions
@@ -90,7 +89,7 @@ catkin_package(
 ## Declare the pcl_ros_tf library
 add_library(pcl_ros_tf src/transforms.cpp)
 target_link_libraries(pcl_ros_tf ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${Eigen3_LIBRARIES} ${PCL_LIBRARIES})
-add_dependencies(pcl_ros_tf pcl_ros_generate_messages_cpp ${catkin_EXPORTED_TARGETS})
+add_dependencies(pcl_ros_tf ${catkin_EXPORTED_TARGETS})
 
 ## Nodelets
 

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -24,7 +24,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>rosconsole</build_depend>
-  <build_depend>genmsg</build_depend>
   <build_depend>roslib</build_depend>
 
   <depend>dynamic_reconfigure</depend>


### PR DESCRIPTION
Close https://github.com/ros-perception/perception_pcl/issues/173

- Remove dependency on genmsg
- Fix missing find_package of message_filters


**Before**

```
% catkin lint .
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_features.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_filters.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_io.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_segmentation.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_surface.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
pcl_ros: error: unconfigured build_depend on 'message_filters'
catkin_lint: checked 1 packages and found 6 problems
catkin_lint: 40 notices have been ignored. Use -W2 to see them
```

**After**

```
% catkin lint .
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_features.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_filters.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_io.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_segmentation.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
pcl_ros: error: nodelet plugin file 'plugins/nodelet/libpcl_ros_surface.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
catkin_lint: checked 1 packages and found 5 problems
catkin_lint: 40 notices have been ignored. Use -W2 to see them
```