### PR TITLE
Fix a bug building on artful.

### DIFF
--- a/pcl_conversions/CMakeLists.txt
+++ b/pcl_conversions/CMakeLists.txt
@@ -1,10 +1,20 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.7)
 project(pcl_conversions)
 
 find_package(catkin REQUIRED COMPONENTS)
 
 find_package(PCL REQUIRED COMPONENTS common io)
 find_package(Eigen3 REQUIRED)
+
+# There is a bug in the Ubuntu Artful (17.10) version of the VTK package,
+# where it includes /usr/include/*-linux-gnu/freetype2 in the include
+# directories (which doesn't exist).  This filters down to the PCL_INCLUDE_DIRS,
+# and causes downstream projects trying to use these libraries to fail to
+# configure properly.  Here we remove those bogus entries so that downstream
+# consumers of this package succeed.
+if(NOT "${PCL_INCLUDE_DIRS}" STREQUAL "")
+  list(FILTER PCL_INCLUDE_DIRS EXCLUDE REGEX "/usr/include/.*-linux-gnu/freetype2")
+endif()
 
 catkin_package(
   INCLUDE_DIRS include

--- a/pcl_conversions/README.rst
+++ b/pcl_conversions/README.rst
@@ -15,7 +15,7 @@ Code & tickets
 +-----------------+------------------------------------------------------------+
 | pcl_conversions | http://ros.org/wiki/pcl_conversions                        |
 +-----------------+------------------------------------------------------------+
-| Issues          | http://github.com/ros-perception/pcl_conversions/issues    |
+| Issues          | http://github.com/ros-perception/perception_pcl/issues    |
 +-----------------+------------------------------------------------------------+
 .. | Documentation   | http://ros-perception.github.com/pcl_conversions/doc       |
 .. +-----------------+------------------------------------------------------------+


### PR DESCRIPTION
This should fix the errors encountered [here](http://build.ros.org/view/Mbin_uA64/job/Mbin_uA64__pcl_ros__ubuntu_artful_amd64__binary/5/consoleFull).  The comment explains it in more detail.  While we are at it, fix the link in the README.rst to point to the right repository.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>