### PR TITLE
Fix pcl conversions links

### DIFF
--- a/pcl_conversions/CMakeLists.txt
+++ b/pcl_conversions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.6.3)
 project(pcl_conversions)
 
 find_package(catkin REQUIRED COMPONENTS)

--- a/pcl_conversions/package.xml
+++ b/pcl_conversions/package.xml
@@ -12,8 +12,8 @@
   <license>BSD</license>
 
   <url>http://wiki.ros.org/pcl_conversions</url>
-  <url type="repository">https://github.com/ros-perception/pcl_conversions</url>
-  <url type="bugtracker">https://github.com/ros-perception/pcl_conversions/issues</url>
+  <url type="repository">https://github.com/ros-perception/perception_pcl</url>
+  <url type="bugtracker">https://github.com/ros-perception/perception_pcl/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 


### PR DESCRIPTION
I noticed that on failing jobs on the buildfarm, it recommends:
"Check the issue tracker 'https://github.com/ros-perception/pcl_conversions/issues' and consider creating a ticket if the problem has not been reported yet"

I also changed the minimal CMake version as `list(FILTER ...)` is available since [CMake 3.6.3](https://cmake.org/cmake/help/v3.6/command/list.html)
