### PR TITLE
Increase limits on CropBox filter parameters

### DIFF
--- a/pcl_ros/cfg/CropBox.cfg
+++ b/pcl_ros/cfg/CropBox.cfg
@@ -11,12 +11,12 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator ()
 # def add (self, name, paramtype, level, description, default = None, min = None, max = None, edit_method = ""):
-gen.add ("min_x", double_t, 0, "X coordinate of the minimum point of the box.", -1, -5, 5)
-gen.add ("max_x", double_t, 0, "X coordinate of the maximum point of the box.",  1, -5, 5)
-gen.add ("min_y", double_t, 0, "Y coordinate of the minimum point of the box.", -1, -5, 5)
-gen.add ("max_y", double_t, 0, "Y coordinate of the maximum point of the box.",  1, -5, 5)
-gen.add ("min_z", double_t, 0, "Z coordinate of the minimum point of the box.", -1, -5, 5)
-gen.add ("max_z", double_t, 0, "Z coordinate of the maximum point of the box.",  1, -5, 5)
+gen.add ("min_x", double_t, 0, "X coordinate of the minimum point of the box.", -1, -1000, 1000)
+gen.add ("max_x", double_t, 0, "X coordinate of the maximum point of the box.",  1, -1000, 1000)
+gen.add ("min_y", double_t, 0, "Y coordinate of the minimum point of the box.", -1, -1000, 1000)
+gen.add ("max_y", double_t, 0, "Y coordinate of the maximum point of the box.",  1, -1000, 1000)
+gen.add ("min_z", double_t, 0, "Z coordinate of the minimum point of the box.", -1, -1000, 1000)
+gen.add ("max_z", double_t, 0, "Z coordinate of the maximum point of the box.",  1, -1000, 1000)
 gen.add ("keep_organized", bool_t, 0, "Set whether the filtered points should be kept and set to NaN, or removed from the PointCloud, thus potentially breaking its organized structure.", False)
 gen.add ("negative", bool_t, 0, "If True the box will be empty Else the remaining points will be the ones in the box", False)
 gen.add ("input_frame", str_t, 0, "The input TF frame the data should be transformed into before processing, if input.header.frame_id is different.", "")


### PR DESCRIPTION
Min and max of CropBox filter was +/- 5m. For a pointcloud from a Velodyne, for example, this is not enough.
Increased to +/- 1000m.

Follow up of https://github.com/ros-perception/perception_pcl/pull/199 and https://github.com/ros-perception/perception_pcl/pull/200