### PR TITLE
pcl_ros: fix exported includes in Ubuntu Artful

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -18,6 +18,21 @@ if(NOT "${PCL_LIBRARIES}" STREQUAL "")
     "vtkRenderingQt")
 endif()
 
+# There is a bug in the Ubuntu Artful (17.10) version of the VTK package,
+# where it includes /usr/include/*-linux-gnu/freetype2 in the include
+# directories (which doesn't exist).  This filters down to the PCL_INCLUDE_DIRS,
+# and causes downstream projects trying to use these libraries to fail to
+# configure properly.  Here we remove those bogus entries so that downstream
+# consumers of this package succeed.
+if(NOT "${PCL_INCLUDE_DIRS}" STREQUAL "")
+  foreach(item ${PCL_INCLUDE_DIRS})
+    string(REGEX MATCH "/usr/include/.*-linux-gnu/freetype2" item ${item})
+    if(item)
+      list(REMOVE_ITEM PCL_INCLUDE_DIRS ${item})
+    endif()
+  endforeach()
+endif()
+
 ## Find catkin packages
 find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure


### PR DESCRIPTION
pcl_ros needs the same fix as pcl_conversions

This blocks building packages depending on pcl_ros for melodic on Ubuntu Artful. The same fix is already in pcl_conversions. pcl_ros needs new release for melodic.

#207 fixed this issue for kinetic, maybe we should do the same for lunar too.