### PR TITLE
Wait for transform in transformPointCloud().

### DIFF
--- a/pcl_ros/src/transforms.cpp
+++ b/pcl_ros/src/transforms.cpp
@@ -58,6 +58,7 @@ transformPointCloud (const std::string &target_frame, const sensor_msgs::PointCl
   tf::StampedTransform transform;
   try
   {
+    tf_listener.waitForTransform (target_frame, in.header.frame_id, in.header.stamp, ros::Duration(1));
     tf_listener.lookupTransform (target_frame, in.header.frame_id, in.header.stamp, transform);
   }
   catch (tf::LookupException &e)


### PR DESCRIPTION
Just wanted to add this myself, but found this fork by @shuntaraw adding a wait for transform in transformPointCloud(). The fact that there is no wait for transform so far means that it depends on sheer luck (and some factors like system load etc.) wether data can be transformed or not when another input frame is selected for the incoming cloud. It's kind of fascinating that no one ran into this in the last 6 years :)