### PR TITLE
use <chrono> and <thread> on Windows

### DIFF
--- a/pcl_ros/tools/pcd_to_pointcloud.cpp
+++ b/pcl_ros/tools/pcd_to_pointcloud.cpp
@@ -49,6 +49,8 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
+#include <chrono>
+#include <thread>
 
 #include "pcl_ros/publisher.h"
 
@@ -116,7 +118,7 @@ class PCDGenerator
           continue;
         }
 
-        usleep (interval);
+        std::this_thread::sleep_for(std::chrono::microseconds(static_cast<uint32_t>(interval)));
 
         if (interval == 0)	// We only publish once if a 0 seconds interval is given
 				{

--- a/pcl_ros/tools/pcd_to_pointcloud.cpp
+++ b/pcl_ros/tools/pcd_to_pointcloud.cpp
@@ -49,9 +49,10 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
+
 #ifdef _WIN32
-#include <chrono>
-#include <thread>
+  #include <chrono>
+  #include <thread>
 #endif
 
 #include "pcl_ros/publisher.h"

--- a/pcl_ros/tools/pcd_to_pointcloud.cpp
+++ b/pcl_ros/tools/pcd_to_pointcloud.cpp
@@ -43,17 +43,16 @@
 
  **/
 
+// STL
+#include <chrono>
+#include <thread>
+
 // ROS core
 #include <ros/ros.h>
 #include <pcl/io/io.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-
-#ifdef _WIN32
-  #include <chrono>
-  #include <thread>
-#endif
 
 #include "pcl_ros/publisher.h"
 
@@ -121,11 +120,7 @@ class PCDGenerator
           continue;
         }
 
-#ifdef _WIN32
         std::this_thread::sleep_for(std::chrono::microseconds(static_cast<uint32_t>(interval)));
-#else
-        usleep(interval);
-#endif
 
         if (interval == 0)	// We only publish once if a 0 seconds interval is given
 				{

--- a/pcl_ros/tools/pcd_to_pointcloud.cpp
+++ b/pcl_ros/tools/pcd_to_pointcloud.cpp
@@ -49,8 +49,10 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
+#ifdef _WIN32
 #include <chrono>
 #include <thread>
+#endif
 
 #include "pcl_ros/publisher.h"
 
@@ -118,7 +120,11 @@ class PCDGenerator
           continue;
         }
 
+#ifdef _WIN32
         std::this_thread::sleep_for(std::chrono::microseconds(static_cast<uint32_t>(interval)));
+#else
+        usleep(interval);
+#endif
 
         if (interval == 0)	// We only publish once if a 0 seconds interval is given
 				{


### PR DESCRIPTION
`usleep` is only available on Linux, use `this_thread::sleep_for` from STL on Windows to work around the issue