### PR TITLE
Catch tf::TransformException in transformPointCloud

### DIFF
--- a/pcl_ros/include/pcl_ros/impl/transforms.hpp
+++ b/pcl_ros/include/pcl_ros/impl/transforms.hpp
@@ -105,12 +105,7 @@ transformPointCloudWithNormals (const std::string &target_frame,
   {
     tf_listener.lookupTransform (target_frame, cloud_in.header.frame_id, fromPCL(cloud_in.header).stamp, transform);
   }
-  catch (tf::LookupException &e)
-  {
-    ROS_ERROR ("%s", e.what ());
-    return (false);
-  }
-  catch (tf::ExtrapolationException &e)
+  catch (const tf::TransformException &e)
   {
     ROS_ERROR ("%s", e.what ());
     return (false);
@@ -139,16 +134,12 @@ transformPointCloud (const std::string &target_frame,
   {
     tf_listener.lookupTransform (target_frame, cloud_in.header.frame_id, fromPCL(cloud_in.header).stamp, transform);
   }
-  catch (tf::LookupException &e)
+  catch (const tf::TransformException &e)
   {
     ROS_ERROR ("%s", e.what ());
     return (false);
   }
-  catch (tf::ExtrapolationException &e)
-  {
-    ROS_ERROR ("%s", e.what ());
-    return (false);
-  }
+
   transformPointCloud (cloud_in, cloud_out, transform);
   cloud_out.header.frame_id = target_frame;
   return (true);
@@ -168,12 +159,7 @@ transformPointCloud (const std::string &target_frame,
   {
     tf_listener.lookupTransform (target_frame, target_time, cloud_in.header.frame_id, fromPCL(cloud_in.header).stamp, fixed_frame, transform);
   }
-  catch (tf::LookupException &e)
-  {
-    ROS_ERROR ("%s", e.what ());
-    return (false);
-  }
-  catch (tf::ExtrapolationException &e)
+  catch (const tf::TransformException &e)
   {
     ROS_ERROR ("%s", e.what ());
     return (false);
@@ -201,12 +187,7 @@ transformPointCloudWithNormals (const std::string &target_frame,
   {
     tf_listener.lookupTransform (target_frame, target_time, cloud_in.header.frame_id, fromPCL(cloud_in.header).stamp, fixed_frame, transform);
   }
-  catch (tf::LookupException &e)
-  {
-    ROS_ERROR ("%s", e.what ());
-    return (false);
-  }
-  catch (tf::ExtrapolationException &e)
+  catch (const tf::TransformException &e)
   {
     ROS_ERROR ("%s", e.what ());
     return (false);

--- a/pcl_ros/src/pcl_ros/io/concatenate_data.cpp
+++ b/pcl_ros/src/pcl_ros/io/concatenate_data.cpp
@@ -212,14 +212,30 @@ pcl_ros::PointCloudConcatenateDataSynchronizer::combineClouds (const PointCloud2
 
   // Transform the point clouds into the specified output frame
   if (output_frame_ != in1.header.frame_id)
-    pcl_ros::transformPointCloud (output_frame_, in1, *in1_t, tf_);
+  {
+    if (!pcl_ros::transformPointCloud (output_frame_, in1, *in1_t, tf_))
+    {
+      NODELET_ERROR ("[%s::combineClouds] Error converting first input dataset from %s to %s.", getName ().c_str (), in1.header.frame_id.c_str (), output_frame_.c_str ());
+      return;
+    }
+  }
   else
+  {
     in1_t = boost::make_shared<PointCloud2> (in1);
+  }
 
   if (output_frame_ != in2.header.frame_id)
-    pcl_ros::transformPointCloud (output_frame_, in2, *in2_t, tf_);
+  {
+    if (!pcl_ros::transformPointCloud (output_frame_, in2, *in2_t, tf_))
+    {
+      NODELET_ERROR ("[%s::combineClouds] Error converting second input dataset from %s to %s.", getName ().c_str (), in2.header.frame_id.c_str (), output_frame_.c_str ());
+      return;
+    }
+  }
   else
+  {
     in2_t = boost::make_shared<PointCloud2> (in2);
+  }
 
   // Concatenate the results
   pcl::concatenatePointCloud (*in1_t, *in2_t, out);

--- a/pcl_ros/src/transforms.cpp
+++ b/pcl_ros/src/transforms.cpp
@@ -60,12 +60,7 @@ transformPointCloud (const std::string &target_frame, const sensor_msgs::PointCl
   {
     tf_listener.lookupTransform (target_frame, in.header.frame_id, in.header.stamp, transform);
   }
-  catch (tf::LookupException &e)
-  {
-    ROS_ERROR ("%s", e.what ());
-    return (false);
-  }
-  catch (tf::ExtrapolationException &e)
+  catch (const tf::TransformException &e)
   {
     ROS_ERROR ("%s", e.what ());
     return (false);


### PR DESCRIPTION
This allows to catch all exceptions, not only `tf::LookupException` and `tf::ExtrapolationException`.

Note that most of the code using `transformPointCloud` already (implicitly) assumes this function doesn't throw any exception, and they check the return value, which is `false` when an exception happened (or something went wrong).

Only this code wasn't checking the return value, so I've also fixed that:
https://github.com/ros-perception/perception_pcl/blob/12482e555dfc295c47dba1e7c14560870c6a6d0e/pcl_ros/src/pcl_ros/io/concatenate_data.cpp#L214-L222