### PR TITLE
[Windows][melodic-devel] Fix Boost linkage issue and binary install location.

### DIFF
--- a/pcl_conversions/CMakeLists.txt
+++ b/pcl_conversions/CMakeLists.txt
@@ -32,6 +32,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(Boost REQUIRED COMPONENTS iostreams)
   find_package(catkin REQUIRED COMPONENTS roscpp pcl_msgs sensor_msgs std_msgs)
   include_directories(
     include
@@ -40,5 +41,5 @@ if(CATKIN_ENABLE_TESTING)
     ${EIGEN3_INCLUDE_DIRS})
 
   catkin_add_gtest(test_pcl_conversions test/test_pcl_conversions.cpp)
-  target_link_libraries(test_pcl_conversions ${catkin_LIBRARIES})
+  target_link_libraries(test_pcl_conversions ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 endif()

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -231,6 +231,13 @@ install(
     pcl_ros_filters
     pcl_ros_surface
     pcl_ros_segmentation
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+install(
+  TARGETS
     pcd_to_pointcloud
     pointcloud_to_pcd
     bag_to_pcd


### PR DESCRIPTION
* On Windows, `Boost.Iostreams` usage implies to link `boost_iostreams-*.lib` at linkage time, so it needs to be added explicitly in `CMakeLists.txt`.
* Follow `catkin` guidance to install `.DLL` files to the correct location: http://docs.ros.org/melodic/api/catkin/html/howto/format2/building_libraries.html