### PR TITLE
General cleanup

### DIFF
--- a/pcl_ros/include/pcl_ros/features/feature.h
+++ b/pcl_ros/include/pcl_ros/features/feature.h
@@ -40,7 +40,6 @@
 
 // PCL includes
 #include <pcl/features/feature.h>
-#include <pcl_msgs/PointIndices.h>
 
 #include "pcl_ros/pcl_nodelet.h"
 #include <message_filters/pass_through.h>

--- a/pcl_ros/include/pcl_ros/features/fpfh.h
+++ b/pcl_ros/include/pcl_ros/features/fpfh.h
@@ -39,7 +39,7 @@
 #define PCL_ROS_FPFH_H_
 
 #include <pcl/features/fpfh.h>
-#include "pcl_ros/features/pfh.h"
+#include "pcl_ros/features/feature.h"
 
 namespace pcl_ros
 {

--- a/pcl_ros/include/pcl_ros/features/fpfh_omp.h
+++ b/pcl_ros/include/pcl_ros/features/fpfh_omp.h
@@ -39,7 +39,7 @@
 #define PCL_ROS_FPFH_OMP_H_
 
 #include <pcl/features/fpfh_omp.h>
-#include "pcl_ros/features/fpfh.h"
+#include "pcl_ros/features/feature.h"
 
 namespace pcl_ros
 {

--- a/pcl_ros/include/pcl_ros/features/normal_3d_omp.h
+++ b/pcl_ros/include/pcl_ros/features/normal_3d_omp.h
@@ -39,7 +39,7 @@
 #define PCL_ROS_NORMAL_3D_OMP_H_
 
 #include <pcl/features/normal_3d_omp.h>
-#include "pcl_ros/features/normal_3d.h"
+#include "pcl_ros/features/feature.h"
 
 namespace pcl_ros
 {

--- a/pcl_ros/include/pcl_ros/features/shot.h
+++ b/pcl_ros/include/pcl_ros/features/shot.h
@@ -38,7 +38,7 @@
 #define PCL_ROS_SHOT_H_
 
 #include <pcl/features/shot.h>
-#include "pcl_ros/features/pfh.h"
+#include "pcl_ros/features/feature.h"
 
 namespace pcl_ros
 {

--- a/pcl_ros/include/pcl_ros/features/shot_omp.h
+++ b/pcl_ros/include/pcl_ros/features/shot_omp.h
@@ -38,7 +38,7 @@
 #define PCL_ROS_SHOT_OMP_H_
 
 #include <pcl/features/shot_omp.h>
-#include "pcl_ros/features/shot.h"
+#include "pcl_ros/features/feature.h"
 
 namespace pcl_ros
 {

--- a/pcl_ros/include/pcl_ros/features/vfh.h
+++ b/pcl_ros/include/pcl_ros/features/vfh.h
@@ -39,7 +39,7 @@
 #define PCL_ROS_FEATURES_VFH_H_
 
 #include <pcl/features/vfh.h>
-#include "pcl_ros/features/fpfh.h"
+#include "pcl_ros/features/feature.h"
 
 namespace pcl_ros
 {

--- a/pcl_ros/include/pcl_ros/filters/filter.h
+++ b/pcl_ros/include/pcl_ros/filters/filter.h
@@ -39,7 +39,6 @@
 #define PCL_ROS_FILTER_H_
 
 // PCL includes
-#include <pcl/filters/filter.h>
 #include "pcl_ros/pcl_nodelet.h"
 
 // Dynamic reconfigure
@@ -99,7 +98,7 @@ namespace pcl_ros
         * \param has_service set to true if the child has a Dynamic Reconfigure service
         */
       virtual bool 
-      child_init (ros::NodeHandle &nh, bool &has_service) 
+      child_init (ros::NodeHandle &/*nh*/, bool &has_service) 
       { 
         has_service = false; 
         return (true); 

--- a/pcl_ros/include/pcl_ros/io/bag_io.h
+++ b/pcl_ros/include/pcl_ros/io/bag_io.h
@@ -38,7 +38,8 @@
 #ifndef PCL_ROS_IO_BAG_IO_H_
 #define PCL_ROS_IO_BAG_IO_H_
 
-#include <pcl_ros/pcl_nodelet.h>
+#include <nodelet/nodelet.h>
+#include <Eigen/Core>
 #include <sensor_msgs/PointCloud2.h>
 #include <rosbag/bag.h>
 #include <rosbag/view.h>

--- a/pcl_ros/include/pcl_ros/io/concatenate_fields.h
+++ b/pcl_ros/include/pcl_ros/io/concatenate_fields.h
@@ -40,10 +40,6 @@
 
 // ROS includes
 #include <nodelet_topic_tools/nodelet_lazy.h>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <message_filters/sync_policies/approximate_time.h>
 
 #include <sensor_msgs/PointCloud2.h>
 

--- a/pcl_ros/include/pcl_ros/pcl_nodelet.h
+++ b/pcl_ros/include/pcl_ros/pcl_nodelet.h
@@ -169,7 +169,7 @@ namespace pcl_ros
         * \param topic_name an optional topic name (only used for printing, defaults to "indices")
         */
       inline bool
-      isValid (const PointIndicesConstPtr &indices, const std::string &topic_name = "indices")
+      isValid (const PointIndicesConstPtr &/*indices*/, const std::string &/*topic_name*/ = "indices")
       {
         /*if (indices->indices.empty ())
         {
@@ -184,7 +184,7 @@ namespace pcl_ros
         * \param topic_name an optional topic name (only used for printing, defaults to "model")
         */
       inline bool
-      isValid (const ModelCoefficientsConstPtr &model, const std::string &topic_name = "model")
+      isValid (const ModelCoefficientsConstPtr &/*model*/, const std::string &/*topic_name*/ = "model")
       {
         /*if (model->values.empty ())
         {

--- a/pcl_ros/include/pcl_ros/surface/convex_hull.h
+++ b/pcl_ros/include/pcl_ros/surface/convex_hull.h
@@ -43,9 +43,6 @@
 // PCL includes
 #include <pcl/surface/convex_hull.h>
 
-// Dynamic reconfigure
-#include <dynamic_reconfigure/server.h>
-
 namespace pcl_ros
 {
   namespace sync_policies = message_filters::sync_policies;

--- a/pcl_ros/src/pcl_ros/features/feature.cpp
+++ b/pcl_ros/src/pcl_ros/features/feature.cpp
@@ -47,9 +47,7 @@
 //#include "pfh.cpp"
 //#include "principal_curvatures.cpp"
 //#include "vfh.cpp"
-#include <pcl/io/io.h>
 #include "pcl_ros/features/feature.h"
-#include <message_filters/null_types.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 void
@@ -177,7 +175,7 @@ pcl_ros::Feature::unsubscribe ()
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::Feature::config_callback (FeatureConfig &config, uint32_t level)
+pcl_ros::Feature::config_callback (FeatureConfig &config, uint32_t /*level*/)
 {
   if (k_ != config.k_search)
   {

--- a/pcl_ros/src/pcl_ros/filters/crop_box.cpp
+++ b/pcl_ros/src/pcl_ros/filters/crop_box.cpp
@@ -54,7 +54,7 @@ pcl_ros::CropBox::child_init (ros::NodeHandle &nh, bool &has_service)
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::CropBox::config_callback (pcl_ros::CropBoxConfig &config, uint32_t level)
+pcl_ros::CropBox::config_callback (pcl_ros::CropBoxConfig &config, uint32_t /*level*/)
 {
   boost::mutex::scoped_lock lock (mutex_);
 
@@ -111,5 +111,5 @@ pcl_ros::CropBox::config_callback (pcl_ros::CropBoxConfig &config, uint32_t leve
 }
 
 typedef pcl_ros::CropBox CropBox;
-PLUGINLIB_EXPORT_CLASS(CropBox,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(CropBox,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/filters/extract_indices.cpp
+++ b/pcl_ros/src/pcl_ros/filters/extract_indices.cpp
@@ -54,7 +54,7 @@ pcl_ros::ExtractIndices::child_init (ros::NodeHandle &nh, bool &has_service)
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::ExtractIndices::config_callback (pcl_ros::ExtractIndicesConfig &config, uint32_t level)
+pcl_ros::ExtractIndices::config_callback (pcl_ros::ExtractIndicesConfig &config, uint32_t /*level*/)
 {
   boost::mutex::scoped_lock lock (mutex_);
 
@@ -66,5 +66,5 @@ pcl_ros::ExtractIndices::config_callback (pcl_ros::ExtractIndicesConfig &config,
 }
 
 typedef pcl_ros::ExtractIndices ExtractIndices;
-PLUGINLIB_EXPORT_CLASS(ExtractIndices,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(ExtractIndices,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/filters/features/feature.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/feature.cpp
@@ -150,7 +150,7 @@ pcl_ros::Feature::onInit ()
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::Feature::config_callback (FeatureConfig &config, uint32_t level)
+pcl_ros::Feature::config_callback (FeatureConfig &config, uint32_t /*level*/)
 {
   if (k_ != config.k_search)
   {

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -35,7 +35,6 @@
  *
  */
 
-#include <pcl/io/io.h>
 #include "pcl_ros/transforms.h"
 #include "pcl_ros/filters/filter.h"
 
@@ -174,7 +173,7 @@ pcl_ros::Filter::onInit ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::Filter::config_callback (pcl_ros::FilterConfig &config, uint32_t level)
+pcl_ros::Filter::config_callback (pcl_ros::FilterConfig &config, uint32_t /*level*/)
 {
   // The following parameters are updated automatically for all PCL_ROS Nodelet Filters as they are inexistent in PCL
   if (tf_input_frame_ != config.input_frame)

--- a/pcl_ros/src/pcl_ros/filters/passthrough.cpp
+++ b/pcl_ros/src/pcl_ros/filters/passthrough.cpp
@@ -53,7 +53,7 @@ pcl_ros::PassThrough::child_init (ros::NodeHandle &nh, bool &has_service)
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::PassThrough::config_callback (pcl_ros::FilterConfig &config, uint32_t level)
+pcl_ros::PassThrough::config_callback (pcl_ros::FilterConfig &config, uint32_t /*level*/)
 {
   boost::mutex::scoped_lock lock (mutex_);
 
@@ -116,5 +116,5 @@ pcl_ros::PassThrough::config_callback (pcl_ros::FilterConfig &config, uint32_t l
 }
 
 typedef pcl_ros::PassThrough PassThrough;
-PLUGINLIB_EXPORT_CLASS(PassThrough,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(PassThrough,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/filters/project_inliers.cpp
+++ b/pcl_ros/src/pcl_ros/filters/project_inliers.cpp
@@ -37,7 +37,6 @@
 
 #include <pluginlib/class_list_macros.h>
 #include "pcl_ros/filters/project_inliers.h"
-#include <pcl/io/io.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
@@ -158,5 +157,5 @@ pcl_ros::ProjectInliers::input_indices_model_callback (const PointCloud2::ConstP
 }
 
 typedef pcl_ros::ProjectInliers ProjectInliers;
-PLUGINLIB_EXPORT_CLASS(ProjectInliers,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(ProjectInliers,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/filters/radius_outlier_removal.cpp
+++ b/pcl_ros/src/pcl_ros/filters/radius_outlier_removal.cpp
@@ -53,7 +53,7 @@ pcl_ros::RadiusOutlierRemoval::child_init (ros::NodeHandle &nh, bool &has_servic
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::RadiusOutlierRemoval::config_callback (pcl_ros::RadiusOutlierRemovalConfig &config, uint32_t level)
+pcl_ros::RadiusOutlierRemoval::config_callback (pcl_ros::RadiusOutlierRemovalConfig &config, uint32_t /*level*/)
 {
   boost::mutex::scoped_lock lock (mutex_);
 
@@ -73,5 +73,5 @@ pcl_ros::RadiusOutlierRemoval::config_callback (pcl_ros::RadiusOutlierRemovalCon
 
 
 typedef pcl_ros::RadiusOutlierRemoval RadiusOutlierRemoval;
-PLUGINLIB_EXPORT_CLASS(RadiusOutlierRemoval,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(RadiusOutlierRemoval,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/filters/statistical_outlier_removal.cpp
+++ b/pcl_ros/src/pcl_ros/filters/statistical_outlier_removal.cpp
@@ -53,7 +53,7 @@ pcl_ros::StatisticalOutlierRemoval::child_init (ros::NodeHandle &nh, bool &has_s
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::StatisticalOutlierRemoval::config_callback (pcl_ros::StatisticalOutlierRemovalConfig &config, uint32_t level)
+pcl_ros::StatisticalOutlierRemoval::config_callback (pcl_ros::StatisticalOutlierRemovalConfig &config, uint32_t /*level*/)
 {
   boost::mutex::scoped_lock lock (mutex_);
 
@@ -77,5 +77,5 @@ pcl_ros::StatisticalOutlierRemoval::config_callback (pcl_ros::StatisticalOutlier
 }
 
 typedef pcl_ros::StatisticalOutlierRemoval StatisticalOutlierRemoval;
-PLUGINLIB_EXPORT_CLASS(StatisticalOutlierRemoval,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(StatisticalOutlierRemoval,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
+++ b/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
@@ -69,7 +69,7 @@ pcl_ros::VoxelGrid::filter (const PointCloud2::ConstPtr &input,
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::VoxelGrid::config_callback (pcl_ros::VoxelGridConfig &config, uint32_t level)
+pcl_ros::VoxelGrid::config_callback (pcl_ros::VoxelGridConfig &config, uint32_t /*level*/)
 {
   boost::mutex::scoped_lock lock (mutex_);
 
@@ -83,7 +83,7 @@ pcl_ros::VoxelGrid::config_callback (pcl_ros::VoxelGridConfig &config, uint32_t 
   }
   
   unsigned int minPointsPerVoxel = impl_.getMinimumPointsNumberPerVoxel ();
-  if (minPointsPerVoxel != config.min_points_per_voxel)
+  if (minPointsPerVoxel != ((unsigned int) config.min_points_per_voxel))
   {
     minPointsPerVoxel = config.min_points_per_voxel;
     NODELET_DEBUG ("[config_callback] Setting the minimum points per voxel to: %u.", minPointsPerVoxel);
@@ -131,5 +131,5 @@ pcl_ros::VoxelGrid::config_callback (pcl_ros::VoxelGridConfig &config, uint32_t 
 }
 
 typedef pcl_ros::VoxelGrid VoxelGrid;
-PLUGINLIB_EXPORT_CLASS(VoxelGrid,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(VoxelGrid,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/io/bag_io.cpp
+++ b/pcl_ros/src/pcl_ros/io/bag_io.cpp
@@ -36,6 +36,7 @@
  */
 
 #include <pluginlib/class_list_macros.h>
+#include <ros/node_handle.h>
 #include "pcl_ros/io/bag_io.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -109,5 +110,5 @@ pcl_ros::BAGReader::onInit ()
 }
 
 typedef pcl_ros::BAGReader BAGReader;
-PLUGINLIB_EXPORT_CLASS(BAGReader,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(BAGReader,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/io/concatenate_data.cpp
+++ b/pcl_ros/src/pcl_ros/io/concatenate_data.cpp
@@ -36,7 +36,6 @@
  */
 
 #include <pluginlib/class_list_macros.h>
-#include <pcl/io/io.h>
 #include "pcl_ros/transforms.h"
 #include "pcl_ros/io/concatenate_data.h"
 
@@ -196,7 +195,7 @@ pcl_ros::PointCloudConcatenateDataSynchronizer::subscribe ()
 void
 pcl_ros::PointCloudConcatenateDataSynchronizer::unsubscribe ()
 {
-  for (int d = 0; d < filters_.size (); ++d)
+  for (size_t d = 0; d < filters_.size (); ++d)
   {
     filters_[d]->unsubscribe ();
   }
@@ -272,6 +271,10 @@ pcl_ros::PointCloudConcatenateDataSynchronizer::input (
           {
             pcl_ros::PointCloudConcatenateDataSynchronizer::combineClouds (*out1, *in7, *out2);
             out1 = out2;
+            if (in8 && in8->width * in8->height > 0)
+            {
+              pcl_ros::PointCloudConcatenateDataSynchronizer::combineClouds (*out2, *in8, *out1);
+            }
           } 
         }
       }
@@ -281,5 +284,5 @@ pcl_ros::PointCloudConcatenateDataSynchronizer::input (
 }
 
 typedef pcl_ros::PointCloudConcatenateDataSynchronizer PointCloudConcatenateDataSynchronizer;
-PLUGINLIB_EXPORT_CLASS(PointCloudConcatenateDataSynchronizer,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(PointCloudConcatenateDataSynchronizer,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/io/concatenate_fields.cpp
+++ b/pcl_ros/src/pcl_ros/io/concatenate_fields.cpp
@@ -38,7 +38,6 @@
 /** \author Radu Bogdan Rusu */
 
 #include <pluginlib/class_list_macros.h>
-#include <pcl/io/io.h>
 #include "pcl_ros/io/concatenate_fields.h"
 
 #include <pcl_conversions/pcl_conversions.h>
@@ -109,9 +108,9 @@ pcl_ros::PointCloudConcatenateFieldsSynchronizer::input_callback (const PointClo
     PointCloud cloud_out = *clouds[0];
 
     // Resize the output dataset
-    int data_size = cloud_out.data.size ();
-    int nr_fields = cloud_out.fields.size ();
-    int nr_points = cloud_out.width * cloud_out.height;
+    size_t data_size = cloud_out.data.size ();
+    size_t nr_fields = cloud_out.fields.size ();
+    size_t nr_points = cloud_out.width * cloud_out.height;
     for (size_t i = 1; i < clouds.size (); ++i)
     {
       assert (clouds[i]->data.size () / (clouds[i]->width * clouds[i]->height) == clouds[i]->point_step);
@@ -143,7 +142,7 @@ pcl_ros::PointCloudConcatenateFieldsSynchronizer::input_callback (const PointClo
 
     // Iterate over each point and perform the appropriate memcpys
     int point_offset = 0;
-    for (int cp = 0; cp < nr_points; ++cp)
+    for (size_t cp = 0; cp < nr_points; ++cp)
     {
       for (size_t i = 0; i < clouds.size (); ++i)
       {
@@ -166,5 +165,5 @@ pcl_ros::PointCloudConcatenateFieldsSynchronizer::input_callback (const PointClo
 }
 
 typedef pcl_ros::PointCloudConcatenateFieldsSynchronizer PointCloudConcatenateFieldsSynchronizer;
-PLUGINLIB_EXPORT_CLASS(PointCloudConcatenateFieldsSynchronizer,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(PointCloudConcatenateFieldsSynchronizer,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/io/io.cpp
+++ b/pcl_ros/src/pcl_ros/io/io.cpp
@@ -51,7 +51,7 @@ typedef nodelet::NodeletDEMUX<sensor_msgs::PointCloud2> NodeletDEMUX;
 //#include "concatenate_fields.cpp"
 //#include "concatenate_data.cpp"
 
-PLUGINLIB_EXPORT_CLASS(NodeletMUX,nodelet::Nodelet);
-PLUGINLIB_EXPORT_CLASS(NodeletDEMUX,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(NodeletMUX,nodelet::Nodelet)
+PLUGINLIB_EXPORT_CLASS(NodeletDEMUX,nodelet::Nodelet)
 //PLUGINLIB_EXPORT_CLASS(NodeletDEMUX_ROS,nodelet::Nodelet);
 

--- a/pcl_ros/src/pcl_ros/io/pcd_io.cpp
+++ b/pcl_ros/src/pcl_ros/io/pcd_io.cpp
@@ -177,6 +177,6 @@ pcl_ros::PCDWriter::input_callback (const PointCloud2ConstPtr &cloud)
 
 typedef pcl_ros::PCDReader PCDReader;
 typedef pcl_ros::PCDWriter PCDWriter;
-PLUGINLIB_EXPORT_CLASS(PCDReader,nodelet::Nodelet);
-PLUGINLIB_EXPORT_CLASS(PCDWriter,nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(PCDReader,nodelet::Nodelet)
+PLUGINLIB_EXPORT_CLASS(PCDWriter,nodelet::Nodelet)
 

--- a/pcl_ros/src/pcl_ros/segmentation/extract_clusters.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/extract_clusters.cpp
@@ -36,7 +36,6 @@
  */
 
 #include <pluginlib/class_list_macros.h>
-#include <pcl/io/io.h>
 #include <pcl/PointIndices.h>
 #include "pcl_ros/segmentation/extract_clusters.h"
 
@@ -138,7 +137,7 @@ pcl_ros::EuclideanClusterExtraction::unsubscribe ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::EuclideanClusterExtraction::config_callback (EuclideanClusterExtractionConfig &config, uint32_t level)
+pcl_ros::EuclideanClusterExtraction::config_callback (EuclideanClusterExtractionConfig &config, uint32_t /*level*/)
 {
   if (impl_.getClusterTolerance () != config.cluster_tolerance)
   {

--- a/pcl_ros/src/pcl_ros/segmentation/extract_polygonal_prism_data.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/extract_polygonal_prism_data.cpp
@@ -38,7 +38,6 @@
 #include <pluginlib/class_list_macros.h>
 #include "pcl_ros/transforms.h"
 #include "pcl_ros/segmentation/extract_polygonal_prism_data.h"
-#include <pcl/io/io.h>
 
 #include <pcl_conversions/pcl_conversions.h>
 
@@ -113,7 +112,7 @@ pcl_ros::ExtractPolygonalPrismData::unsubscribe ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::ExtractPolygonalPrismData::config_callback (ExtractPolygonalPrismDataConfig &config, uint32_t level)
+pcl_ros::ExtractPolygonalPrismData::config_callback (ExtractPolygonalPrismDataConfig &config, uint32_t /*level*/)
 {
   double height_min, height_max;
   impl_.getHeightLimits (height_min, height_max);

--- a/pcl_ros/src/pcl_ros/segmentation/sac_segmentation.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/sac_segmentation.cpp
@@ -37,7 +37,6 @@
 
 #include <pluginlib/class_list_macros.h>
 #include "pcl_ros/segmentation/sac_segmentation.h"
-#include <pcl/io/io.h>
 
 #include <pcl_conversions/pcl_conversions.h>
 
@@ -192,7 +191,7 @@ pcl_ros::SACSegmentation::unsubscribe ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::SACSegmentation::config_callback (SACSegmentationConfig &config, uint32_t level)
+pcl_ros::SACSegmentation::config_callback (SACSegmentationConfig &config, uint32_t /*level*/)
 {
   boost::mutex::scoped_lock lock (mutex_);
 
@@ -518,7 +517,7 @@ pcl_ros::SACSegmentationFromNormals::axis_callback (const pcl_msgs::ModelCoeffic
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::SACSegmentationFromNormals::config_callback (SACSegmentationFromNormalsConfig &config, uint32_t level)
+pcl_ros::SACSegmentationFromNormals::config_callback (SACSegmentationFromNormalsConfig &config, uint32_t /*level*/)
 {
   boost::mutex::scoped_lock lock (mutex_);
 

--- a/pcl_ros/src/pcl_ros/segmentation/segment_differences.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/segment_differences.cpp
@@ -37,7 +37,6 @@
 
 #include <pluginlib/class_list_macros.h>
 #include "pcl_ros/segmentation/segment_differences.h"
-#include <pcl/io/io.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
@@ -93,7 +92,7 @@ pcl_ros::SegmentDifferences::unsubscribe ()
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::SegmentDifferences::config_callback (SegmentDifferencesConfig &config, uint32_t level)
+pcl_ros::SegmentDifferences::config_callback (SegmentDifferencesConfig &config, uint32_t /*level*/)
 {
   if (impl_.getDistanceThreshold () != config.distance_threshold)
   {

--- a/pcl_ros/src/pcl_ros/surface/convex_hull.cpp
+++ b/pcl_ros/src/pcl_ros/surface/convex_hull.cpp
@@ -36,7 +36,6 @@
  */
 
 #include <pluginlib/class_list_macros.h>
-#include <pcl/common/io.h>
 #include "pcl_ros/surface/convex_hull.h"
 #include <geometry_msgs/PolygonStamped.h>
 

--- a/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
+++ b/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
@@ -37,7 +37,6 @@
 
 #include <pluginlib/class_list_macros.h>
 #include "pcl_ros/surface/moving_least_squares.h"
-#include <pcl/io/io.h>
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
 pcl_ros::MovingLeastSquares::onInit ()
@@ -190,7 +189,7 @@ pcl_ros::MovingLeastSquares::input_indices_callback (const PointCloudInConstPtr 
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 void
-pcl_ros::MovingLeastSquares::config_callback (MLSConfig &config, uint32_t level)
+pcl_ros::MovingLeastSquares::config_callback (MLSConfig &config, uint32_t /*level*/)
 {
   // \Note Zoli, shouldn't this be implemented in MLS too?
   /*if (k_ != config.k_search)

--- a/pcl_ros/src/transforms.cpp
+++ b/pcl_ros/src/transforms.cpp
@@ -36,8 +36,6 @@
 
 #include <sensor_msgs/PointCloud2.h>
 #include <tf2_eigen/tf2_eigen.h>
-#include <pcl/common/io.h>
-#include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include "pcl_ros/transforms.h"
 #include "pcl_ros/impl/transforms.hpp"

--- a/pcl_ros/tools/bag_to_pcd.cpp
+++ b/pcl_ros/tools/bag_to_pcd.cpp
@@ -44,12 +44,9 @@ Cloud Data) format.
 
  **/
 
-#include <sstream>
 #include <boost/filesystem.hpp>
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
-#include <pcl/io/io.h>
-#include <pcl/io/pcd_io.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include "pcl_ros/transforms.h"
 #include <tf/transform_listener.h>
@@ -83,7 +80,7 @@ int
   {
     bag.open (argv[1], rosbag::bagmode::Read);
   } 
-  catch (rosbag::BagException) 
+  catch (const rosbag::BagException&) 
   {
     std::cerr << "Error opening file " << argv[1] << std::endl;
     return (-1);

--- a/pcl_ros/tools/convert_pcd_to_image.cpp
+++ b/pcl_ros/tools/convert_pcd_to_image.cpp
@@ -49,9 +49,6 @@
 #include <ros/ros.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/PointCloud2.h>
-#include <pcl/io/io.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 /* ---[ */

--- a/pcl_ros/tools/convert_pointcloud_to_image.cpp
+++ b/pcl_ros/tools/convert_pointcloud_to_image.cpp
@@ -44,7 +44,6 @@
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/PointCloud2.h>
 //pcl::toROSMsg
-#include <pcl/io/pcd_io.h>
 //conversions from PCL custom types
 #include <pcl_conversions/pcl_conversions.h>
 //stl stuff

--- a/pcl_ros/tools/pcd_to_pointcloud.cpp
+++ b/pcl_ros/tools/pcd_to_pointcloud.cpp
@@ -45,7 +45,6 @@
 
 // ROS core
 #include <ros/ros.h>
-#include <pcl/io/pcd_io.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <string>

--- a/pcl_ros/tools/pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/pointcloud_to_pcd.cpp
@@ -38,20 +38,14 @@
 // ROS core
 #include <ros/ros.h>
 
-#include <sensor_msgs/PointCloud2.h>
-
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_eigen/tf2_eigen.h>
 
 // PCL includes
-#include <pcl/io/io.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 
 #include <pcl_conversions/pcl_conversions.h>
-
-#include <Eigen/Geometry>
 
 using namespace std;
 

--- a/pcl_ros/tools/pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/pointcloud_to_pcd.cpp
@@ -116,20 +116,20 @@ class PointCloudToPCD
 
       pcl::PCDWriter writer;
       if(binary_)
-	{
-	  if(compressed_)
-	    {
-	      writer.writeBinaryCompressed (ss.str (), *cloud, v, q);
-	    }
-	  else
-	    {
-	      writer.writeBinary (ss.str (), *cloud, v, q);
-	    }
-	}
+      {
+        if(compressed_)
+        {
+          writer.writeBinaryCompressed (ss.str (), *cloud, v, q);
+        }
+        else
+        {
+          writer.writeBinary (ss.str (), *cloud, v, q);
+        }
+      }
       else
-	{
-	  writer.writeASCII (ss.str (), *cloud, v, q, 8);
-	}
+      {
+        writer.writeASCII (ss.str (), *cloud, v, q, 8);
+      }
 
     }
 
@@ -153,20 +153,20 @@ class PointCloudToPCD
       priv_nh.getParam ("compressed", compressed_);
       priv_nh.getParam ("filename", filename_);
       if(binary_)
-	{
-	  if(compressed_)
-	    {
-	      ROS_INFO_STREAM ("Saving as binary compressed PCD");
-	    }
-	  else
-	    {
-	      ROS_INFO_STREAM ("Saving as binary PCD");
-	    }
-	}
+      {
+        if(compressed_)
+        {
+          ROS_INFO_STREAM ("Saving as binary compressed PCD");
+        }
+        else
+        {
+          ROS_INFO_STREAM ("Saving as binary uncompressed PCD");
+        }
+      }
       else
-	{
-	  ROS_INFO_STREAM ("Saving as binary PCD");
-	}
+      {
+        ROS_INFO_STREAM ("Saving as ASCII PCD");
+      }
 
       if (filename_ != "")
       {


### PR DESCRIPTION
- Remove unnecessary includes (as recommended by include-what-you-use)
- Comment out unused parameters (to fix g++ warnings)
- Remove unnecessary semicolons
- Change type from int to size_t where appropriate
- Fix output error and improve formatting in pointcloud_to_pcd.cpp
- Add some code in concatenate_data.cpp that has been seemingly forgotten
- Other minor things