### PR TITLE
Add static message field mapping to Serializer class

### DIFF
--- a/pcl_ros/include/pcl_ros/point_cloud.h
+++ b/pcl_ros/include/pcl_ros/point_cloud.h
@@ -59,29 +59,6 @@ namespace pcl
 
 namespace ros 
 {
-  // In ROS 1.3.1+, we can specialize the functor used to create PointCloud<T> objects
-  // on the subscriber side. This allows us to generate the mapping between message
-  // data and object fields only once and reuse it.
-#if ROS_VERSION_MINIMUM(1, 3, 1)
-  template<typename T>
-  struct DefaultMessageCreator<pcl::PointCloud<T> >
-  {
-    boost::shared_ptr<pcl::MsgFieldMap> mapping_;
-
-    DefaultMessageCreator()
-      : mapping_( boost::make_shared<pcl::MsgFieldMap>() )
-    {
-    }
-    
-    boost::shared_ptr<pcl::PointCloud<T> > operator() ()
-    {
-      boost::shared_ptr<pcl::PointCloud<T> > msg (new pcl::PointCloud<T> ());
-      pcl::detail::getMapping(*msg) = mapping_;
-      return msg;
-    }
-  };
-#endif
-
   namespace message_traits 
   {
     template<typename T> struct MD5Sum<pcl::PointCloud<T> >

--- a/pcl_ros/include/pcl_ros/point_cloud.h
+++ b/pcl_ros/include/pcl_ros/point_cloud.h
@@ -206,15 +206,13 @@ namespace ros
         stream.next(fields);
 
         // Construct field mapping if deserializing for the first time
-        boost::shared_ptr<pcl::MsgFieldMap>& mapping_ptr = pcl::detail::getMapping(m);
-        if (!mapping_ptr)
-        {
-          // This normally should get allocated by DefaultMessageCreator, but just in case
-          mapping_ptr = boost::make_shared<pcl::MsgFieldMap>();
-        }
-        pcl::MsgFieldMap& mapping = *mapping_ptr;
+        static pcl::MsgFieldMap mapping;
+        static boost::mutex mutex;
         if (mapping.empty())
-          pcl::createMapping<T> (fields, mapping);
+        {
+          boost::mutex::scoped_lock lock(mutex);
+          pcl::createMapping<T>(fields, mapping);
+        }
 
         uint8_t is_bigendian;
         stream.next(is_bigendian); // ignoring...


### PR DESCRIPTION
Currently, `Serializer` caches computed message field mapping in a [protected field](https://github.com/taketwo/pcl/blob/0a6508ab6c18b5adff3aaf6ef1d2884647f9acba/common/include/pcl/point_cloud.h#L606) of `pcl::PointCloud<T>` class. This commit adds a static field to the Serializer class and stores the mapping there instead.

Motivation: as a part of `boost::shared_ptr -> std::shared_ptr` [migration](https://github.com/PointCloudLibrary/pcl/issues/2792) in PCL we have changed the type of the aforementioned protected field. Later on we were informed that this broke `pcl_ros`. This was unexpected since the field and the associated accessor function are not a public API. After some investigation, we came to the conclusion that `pcl_ros` is probably the only user of that field. With this in mind, we'd like to get rid of it altogether. Therefore, this commit serves two purposes: unbreak pcl_ros for PCL master and get rid of the dependency on non-public API that is going to be deprecated/removed soon.

Implementation note: I've added a mutex to avoid problems if `Serializer` is used simultaneously from several threads for the first time. Not sure if this is needed; is such a situation possible?