### PR TITLE
Added missing header for boost::mutex

### DIFF
--- a/pcl_ros/include/pcl_ros/point_cloud.h
+++ b/pcl_ros/include/pcl_ros/point_cloud.h
@@ -10,6 +10,7 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <boost/mpl/size.hpp>
 #include <boost/ref.hpp>
+#include <boost/thread/mutex.hpp>
 
 namespace pcl 
 {


### PR DESCRIPTION
ros-perception/perception_pcl#258 Added a mutex to the point cloud serialisation code without adding an include to define boost::mutex. On a clean compile this missing dependency causes the compilation to fail