### PR TITLE
Changes in preparation for PCL 1.11

### DIFF
--- a/pcl_ros/include/pcl_ros/features/feature.h
+++ b/pcl_ros/include/pcl_ros/features/feature.h
@@ -69,8 +69,8 @@ namespace pcl_ros
       typedef pcl::KdTree<pcl::PointXYZ>::Ptr KdTreePtr;
 
       typedef pcl::PointCloud<pcl::PointXYZ> PointCloudIn;
-      typedef PointCloudIn::Ptr PointCloudInPtr;
-      typedef PointCloudIn::ConstPtr PointCloudInConstPtr;
+      typedef boost::shared_ptr<PointCloudIn> PointCloudInPtr;
+      typedef boost::shared_ptr<const PointCloudIn> PointCloudInConstPtr;
 
       typedef pcl::IndicesPtr IndicesPtr;
       typedef pcl::IndicesConstPtr IndicesConstPtr;
@@ -190,8 +190,8 @@ namespace pcl_ros
       typedef sensor_msgs::PointCloud2 PointCloud2;
 
       typedef pcl::PointCloud<pcl::Normal> PointCloudN;
-      typedef PointCloudN::Ptr PointCloudNPtr;
-      typedef PointCloudN::ConstPtr PointCloudNConstPtr;
+      typedef boost::shared_ptr<PointCloudN> PointCloudNPtr;
+      typedef boost::shared_ptr<const PointCloudN> PointCloudNConstPtr;
 
       FeatureFromNormals () : normals_() {};
 

--- a/pcl_ros/include/pcl_ros/features/feature.h
+++ b/pcl_ros/include/pcl_ros/features/feature.h
@@ -152,7 +152,7 @@ namespace pcl_ros
         indices.header.stamp = pcl_conversions::fromPCL(input->header).stamp;
         PointCloudIn cloud;
         cloud.header.stamp = input->header.stamp;
-        nf_pc_.add (cloud.makeShared ());
+        nf_pc_.add (ros_ptr(cloud.makeShared ()));
         nf_pi_.add (boost::make_shared<PointIndices> (indices));
       }
 

--- a/pcl_ros/include/pcl_ros/features/feature.h
+++ b/pcl_ros/include/pcl_ros/features/feature.h
@@ -72,8 +72,8 @@ namespace pcl_ros
       typedef PointCloudIn::Ptr PointCloudInPtr;
       typedef PointCloudIn::ConstPtr PointCloudInConstPtr;
 
-      typedef boost::shared_ptr <std::vector<int> > IndicesPtr;
-      typedef boost::shared_ptr <const std::vector<int> > IndicesConstPtr;
+      typedef pcl::IndicesPtr IndicesPtr;
+      typedef pcl::IndicesConstPtr IndicesConstPtr;
 
       /** \brief Empty constructor. */
       Feature () : /*input_(), indices_(), surface_(), */tree_(), k_(0), search_radius_(0),

--- a/pcl_ros/include/pcl_ros/filters/filter.h
+++ b/pcl_ros/include/pcl_ros/filters/filter.h
@@ -58,8 +58,8 @@ namespace pcl_ros
     public:
       typedef sensor_msgs::PointCloud2 PointCloud2;
 
-      typedef boost::shared_ptr <std::vector<int> > IndicesPtr;
-      typedef boost::shared_ptr <const std::vector<int> > IndicesConstPtr;
+      typedef pcl::IndicesPtr IndicesPtr;
+      typedef pcl::IndicesConstPtr IndicesConstPtr;
 
       Filter () {}
 

--- a/pcl_ros/include/pcl_ros/pcl_nodelet.h
+++ b/pcl_ros/include/pcl_ros/pcl_nodelet.h
@@ -48,6 +48,7 @@
 // PCL includes
 #include <pcl_msgs/PointIndices.h>
 #include <pcl_msgs/ModelCoefficients.h>
+#include <pcl/pcl_base.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include "pcl_ros/point_cloud.h"
@@ -86,8 +87,8 @@ namespace pcl_ros
       typedef ModelCoefficients::Ptr ModelCoefficientsPtr;
       typedef ModelCoefficients::ConstPtr ModelCoefficientsConstPtr;
 
-      typedef boost::shared_ptr <std::vector<int> > IndicesPtr;
-      typedef boost::shared_ptr <const std::vector<int> > IndicesConstPtr;
+      typedef pcl::IndicesPtr IndicesPtr;
+      typedef pcl::IndicesConstPtr IndicesConstPtr;
 
       /** \brief Empty constructor. */
       PCLNodelet () : use_indices_ (false), latched_indices_ (false),

--- a/pcl_ros/include/pcl_ros/pcl_nodelet.h
+++ b/pcl_ros/include/pcl_ros/pcl_nodelet.h
@@ -76,8 +76,8 @@ namespace pcl_ros
       typedef sensor_msgs::PointCloud2 PointCloud2;
 
       typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
-      typedef PointCloud::Ptr PointCloudPtr;
-      typedef PointCloud::ConstPtr PointCloudConstPtr;
+      typedef boost::shared_ptr<PointCloud> PointCloudPtr;
+      typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
 
       typedef pcl_msgs::PointIndices PointIndices;
       typedef PointIndices::Ptr PointIndicesPtr;

--- a/pcl_ros/include/pcl_ros/segmentation/extract_polygonal_prism_data.h
+++ b/pcl_ros/include/pcl_ros/segmentation/extract_polygonal_prism_data.h
@@ -64,8 +64,8 @@ namespace pcl_ros
   class ExtractPolygonalPrismData : public PCLNodelet
   {
     typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
-    typedef PointCloud::Ptr PointCloudPtr;
-    typedef PointCloud::ConstPtr PointCloudConstPtr;
+    typedef boost::shared_ptr<PointCloud> PointCloudPtr;
+    typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
 
     protected:
        /** \brief The output PointIndices publisher. */

--- a/pcl_ros/include/pcl_ros/segmentation/sac_segmentation.h
+++ b/pcl_ros/include/pcl_ros/segmentation/sac_segmentation.h
@@ -61,8 +61,8 @@ namespace pcl_ros
   class SACSegmentation : public PCLNodelet
   {
     typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
-    typedef PointCloud::Ptr PointCloudPtr;
-    typedef PointCloud::ConstPtr PointCloudConstPtr;
+    typedef boost::shared_ptr<PointCloud> PointCloudPtr;
+    typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
 
     public:
       /** \brief Constructor. */
@@ -181,12 +181,12 @@ namespace pcl_ros
   class SACSegmentationFromNormals: public SACSegmentation
   {
     typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
-    typedef PointCloud::Ptr PointCloudPtr;
-    typedef PointCloud::ConstPtr PointCloudConstPtr;
+    typedef boost::shared_ptr<PointCloud> PointCloudPtr;
+    typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
 
     typedef pcl::PointCloud<pcl::Normal> PointCloudN;
-    typedef PointCloudN::Ptr PointCloudNPtr;
-    typedef PointCloudN::ConstPtr PointCloudNConstPtr;
+    typedef boost::shared_ptr<PointCloudN> PointCloudNPtr;
+    typedef boost::shared_ptr<const PointCloudN> PointCloudNConstPtr;
 
     public:
       /** \brief Set the input TF frame the data should be transformed into before processing, if input.header.frame_id is different.

--- a/pcl_ros/include/pcl_ros/segmentation/segment_differences.h
+++ b/pcl_ros/include/pcl_ros/segmentation/segment_differences.h
@@ -60,8 +60,8 @@ namespace pcl_ros
   class SegmentDifferences : public PCLNodelet
   {
     typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
-    typedef PointCloud::Ptr PointCloudPtr;
-    typedef PointCloud::ConstPtr PointCloudConstPtr;
+    typedef boost::shared_ptr<PointCloud> PointCloudPtr;
+    typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
 
     public:
       /** \brief Empty constructor. */

--- a/pcl_ros/include/pcl_ros/surface/convex_hull.h
+++ b/pcl_ros/include/pcl_ros/surface/convex_hull.h
@@ -53,8 +53,8 @@ namespace pcl_ros
   class ConvexHull2D : public PCLNodelet
   {
     typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
-    typedef PointCloud::Ptr PointCloudPtr;
-    typedef PointCloud::ConstPtr PointCloudConstPtr;
+    typedef boost::shared_ptr<PointCloud> PointCloudPtr;
+    typedef boost::shared_ptr<const PointCloud> PointCloudConstPtr;
 
     private:
       /** \brief Nodelet initialization routine. */

--- a/pcl_ros/include/pcl_ros/surface/moving_least_squares.h
+++ b/pcl_ros/include/pcl_ros/surface/moving_least_squares.h
@@ -62,8 +62,8 @@ namespace pcl_ros
     typedef pcl::PointNormal NormalOut;
 
     typedef pcl::PointCloud<PointIn> PointCloudIn;
-    typedef PointCloudIn::Ptr PointCloudInPtr;
-    typedef PointCloudIn::ConstPtr PointCloudInConstPtr;
+    typedef boost::shared_ptr<PointCloudIn> PointCloudInPtr;
+    typedef boost::shared_ptr<const PointCloudIn> PointCloudInConstPtr;
     typedef pcl::PointCloud<NormalOut> NormalCloudOut;
 
     typedef pcl::KdTree<PointIn> KdTree;

--- a/pcl_ros/src/pcl_ros/features/boundary.cpp
+++ b/pcl_ros/src/pcl_ros/features/boundary.cpp
@@ -43,7 +43,7 @@ pcl_ros::BoundaryEstimation::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void
@@ -57,17 +57,17 @@ pcl_ros::BoundaryEstimation::computePublish (const PointCloudInConstPtr &cloud,
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
-  impl_.setInputNormals (normals);
+  impl_.setSearchSurface (pcl_ptr(surface));
+  impl_.setInputNormals (pcl_ptr(normals));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
 
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::BoundaryEstimation BoundaryEstimation;

--- a/pcl_ros/src/pcl_ros/features/fpfh.cpp
+++ b/pcl_ros/src/pcl_ros/features/fpfh.cpp
@@ -43,7 +43,7 @@ pcl_ros::FPFHEstimation::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -57,10 +57,10 @@ pcl_ros::FPFHEstimation::computePublish (const PointCloudInConstPtr &cloud,
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
-  impl_.setInputNormals (normals);
+  impl_.setSearchSurface (pcl_ptr(surface));
+  impl_.setInputNormals (pcl_ptr(normals));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -68,7 +68,7 @@ pcl_ros::FPFHEstimation::computePublish (const PointCloudInConstPtr &cloud,
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::FPFHEstimation FPFHEstimation;

--- a/pcl_ros/src/pcl_ros/features/fpfh_omp.cpp
+++ b/pcl_ros/src/pcl_ros/features/fpfh_omp.cpp
@@ -43,7 +43,7 @@ pcl_ros::FPFHEstimationOMP::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -57,10 +57,10 @@ pcl_ros::FPFHEstimationOMP::computePublish (const PointCloudInConstPtr &cloud,
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
-  impl_.setInputNormals (normals);
+  impl_.setSearchSurface (pcl_ptr(surface));
+  impl_.setInputNormals (pcl_ptr(normals));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -68,7 +68,7 @@ pcl_ros::FPFHEstimationOMP::computePublish (const PointCloudInConstPtr &cloud,
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::FPFHEstimationOMP FPFHEstimationOMP;

--- a/pcl_ros/src/pcl_ros/features/moment_invariants.cpp
+++ b/pcl_ros/src/pcl_ros/features/moment_invariants.cpp
@@ -43,7 +43,7 @@ pcl_ros::MomentInvariantsEstimation::emptyPublish (const PointCloudInConstPtr &c
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -56,9 +56,9 @@ pcl_ros::MomentInvariantsEstimation::computePublish (const PointCloudInConstPtr 
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
+  impl_.setSearchSurface (pcl_ptr(surface));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -66,7 +66,7 @@ pcl_ros::MomentInvariantsEstimation::computePublish (const PointCloudInConstPtr 
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::MomentInvariantsEstimation MomentInvariantsEstimation;

--- a/pcl_ros/src/pcl_ros/features/normal_3d.cpp
+++ b/pcl_ros/src/pcl_ros/features/normal_3d.cpp
@@ -43,7 +43,7 @@ pcl_ros::NormalEstimation::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -56,9 +56,9 @@ pcl_ros::NormalEstimation::computePublish (const PointCloudInConstPtr &cloud,
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
+  impl_.setSearchSurface (pcl_ptr(surface));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -66,7 +66,7 @@ pcl_ros::NormalEstimation::computePublish (const PointCloudInConstPtr &cloud,
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::NormalEstimation NormalEstimation;

--- a/pcl_ros/src/pcl_ros/features/normal_3d_omp.cpp
+++ b/pcl_ros/src/pcl_ros/features/normal_3d_omp.cpp
@@ -43,7 +43,7 @@ pcl_ros::NormalEstimationOMP::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -56,9 +56,9 @@ pcl_ros::NormalEstimationOMP::computePublish (const PointCloudInConstPtr &cloud,
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
+  impl_.setSearchSurface (pcl_ptr(surface));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -66,7 +66,7 @@ pcl_ros::NormalEstimationOMP::computePublish (const PointCloudInConstPtr &cloud,
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::NormalEstimationOMP NormalEstimationOMP;

--- a/pcl_ros/src/pcl_ros/features/normal_3d_tbb.cpp
+++ b/pcl_ros/src/pcl_ros/features/normal_3d_tbb.cpp
@@ -45,7 +45,7 @@ pcl_ros::NormalEstimationTBB::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloud output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -71,7 +71,7 @@ pcl_ros::NormalEstimationTBB::computePublish (const PointCloudInConstPtr &cloud,
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::NormalEstimationTBB NormalEstimationTBB;

--- a/pcl_ros/src/pcl_ros/features/pfh.cpp
+++ b/pcl_ros/src/pcl_ros/features/pfh.cpp
@@ -43,7 +43,7 @@ pcl_ros::PFHEstimation::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -57,10 +57,10 @@ pcl_ros::PFHEstimation::computePublish (const PointCloudInConstPtr &cloud,
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
-  impl_.setInputNormals (normals);
+  impl_.setSearchSurface (pcl_ptr(surface));
+  impl_.setInputNormals (pcl_ptr(normals));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -68,7 +68,7 @@ pcl_ros::PFHEstimation::computePublish (const PointCloudInConstPtr &cloud,
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::PFHEstimation PFHEstimation;

--- a/pcl_ros/src/pcl_ros/features/principal_curvatures.cpp
+++ b/pcl_ros/src/pcl_ros/features/principal_curvatures.cpp
@@ -43,7 +43,7 @@ pcl_ros::PrincipalCurvaturesEstimation::emptyPublish (const PointCloudInConstPtr
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -57,10 +57,10 @@ pcl_ros::PrincipalCurvaturesEstimation::computePublish (const PointCloudInConstP
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
-  impl_.setInputNormals (normals);
+  impl_.setSearchSurface (pcl_ptr(surface));
+  impl_.setInputNormals (pcl_ptr(normals));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -68,7 +68,7 @@ pcl_ros::PrincipalCurvaturesEstimation::computePublish (const PointCloudInConstP
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::PrincipalCurvaturesEstimation PrincipalCurvaturesEstimation;

--- a/pcl_ros/src/pcl_ros/features/shot.cpp
+++ b/pcl_ros/src/pcl_ros/features/shot.cpp
@@ -42,7 +42,7 @@ pcl_ros::SHOTEstimation::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -56,10 +56,10 @@ pcl_ros::SHOTEstimation::computePublish (const PointCloudInConstPtr &cloud,
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
-  impl_.setInputNormals (normals);
+  impl_.setSearchSurface (pcl_ptr(surface));
+  impl_.setInputNormals (pcl_ptr(normals));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -67,7 +67,7 @@ pcl_ros::SHOTEstimation::computePublish (const PointCloudInConstPtr &cloud,
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::SHOTEstimation SHOTEstimation;

--- a/pcl_ros/src/pcl_ros/features/shot_omp.cpp
+++ b/pcl_ros/src/pcl_ros/features/shot_omp.cpp
@@ -42,7 +42,7 @@ pcl_ros::SHOTEstimationOMP::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -56,10 +56,10 @@ pcl_ros::SHOTEstimationOMP::computePublish (const PointCloudInConstPtr &cloud,
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
-  impl_.setInputNormals (normals);
+  impl_.setSearchSurface (pcl_ptr(surface));
+  impl_.setInputNormals (pcl_ptr(normals));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -67,7 +67,7 @@ pcl_ros::SHOTEstimationOMP::computePublish (const PointCloudInConstPtr &cloud,
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::SHOTEstimationOMP SHOTEstimationOMP;

--- a/pcl_ros/src/pcl_ros/features/vfh.cpp
+++ b/pcl_ros/src/pcl_ros/features/vfh.cpp
@@ -43,7 +43,7 @@ pcl_ros::VFHEstimation::emptyPublish (const PointCloudInConstPtr &cloud)
 {
   PointCloudOut output;
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 void 
@@ -57,10 +57,10 @@ pcl_ros::VFHEstimation::computePublish (const PointCloudInConstPtr &cloud,
   impl_.setRadiusSearch (search_radius_);
 
   // Set the inputs
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices);
-  impl_.setSearchSurface (surface);
-  impl_.setInputNormals (normals);
+  impl_.setSearchSurface (pcl_ptr(surface));
+  impl_.setInputNormals (pcl_ptr(normals));
   // Estimate the feature
   PointCloudOut output;
   impl_.compute (output);
@@ -68,7 +68,7 @@ pcl_ros::VFHEstimation::computePublish (const PointCloudInConstPtr &cloud,
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::VFHEstimation VFHEstimation;

--- a/pcl_ros/src/pcl_ros/segmentation/extract_clusters.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/extract_clusters.cpp
@@ -202,7 +202,7 @@ pcl_ros::EuclideanClusterExtraction::input_indices_callback (
   if (indices)
     indices_ptr.reset (new std::vector<int> (indices->indices));
 
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices_ptr);
 
   std::vector<pcl::PointIndices> clusters;
@@ -239,7 +239,7 @@ pcl_ros::EuclideanClusterExtraction::input_indices_callback (
       header.stamp += ros::Duration (i * 0.001);
       toPCL(header, output.header);
       // Publish a Boost shared ptr const data
-      pub_output_.publish (output.makeShared ());
+      pub_output_.publish (ros_ptr(output.makeShared ()));
       NODELET_DEBUG ("[segmentAndPublish] Published cluster %zu (with %zu values and stamp %f) on topic %s",
                      i, clusters[i].indices.size (), header.stamp.toSec (), pnh_->resolveName ("output").c_str ());
     }

--- a/pcl_ros/src/pcl_ros/segmentation/extract_polygonal_prism_data.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/extract_polygonal_prism_data.cpp
@@ -189,16 +189,16 @@ pcl_ros::ExtractPolygonalPrismData::input_hull_indices_callback (
       pub_output_.publish (inliers);
       return;
     }
-    impl_.setInputPlanarHull (planar_hull.makeShared ());
+    impl_.setInputPlanarHull (pcl_ptr(planar_hull.makeShared ()));
   }
   else
-    impl_.setInputPlanarHull (hull);
+    impl_.setInputPlanarHull (pcl_ptr(hull));
 
   IndicesPtr indices_ptr;
   if (indices && !indices->header.frame_id.empty ())
     indices_ptr.reset (new std::vector<int> (indices->indices));
 
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices_ptr);
 
   // Final check if the data is empty (remember that indices are set to the size of the data -- if indices* = NULL)

--- a/pcl_ros/src/pcl_ros/segmentation/sac_segmentation.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/sac_segmentation.cpp
@@ -324,7 +324,7 @@ pcl_ros::SACSegmentation::input_indices_callback (const PointCloudConstPtr &clou
   if (indices && !indices->header.frame_id.empty ())
     indices_ptr.reset (new std::vector<int> (indices->indices));
 
-  impl_.setInputCloud (cloud_tf);
+  impl_.setInputCloud (pcl_ptr(cloud_tf));
   impl_.setIndices (indices_ptr);
 
   // Final check if the data is empty (remember that indices are set to the size of the data -- if indices* = NULL)
@@ -651,8 +651,8 @@ pcl_ros::SACSegmentationFromNormals::input_normals_indices_callback (
     return;
   }
 
-  impl_.setInputCloud (cloud);
-  impl_.setInputNormals (cloud_normals);
+  impl_.setInputCloud (pcl_ptr(cloud));
+  impl_.setInputNormals (pcl_ptr(cloud_normals));
 
   IndicesPtr indices_ptr;
   if (indices && !indices->header.frame_id.empty ())

--- a/pcl_ros/src/pcl_ros/segmentation/segment_differences.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/segment_differences.cpp
@@ -115,7 +115,7 @@ pcl_ros::SegmentDifferences::input_target_callback (const PointCloudConstPtr &cl
     NODELET_ERROR ("[%s::input_indices_callback] Invalid input!", getName ().c_str ());
     PointCloud output;
     output.header = cloud->header;
-    pub_output_.publish (output.makeShared ());
+    pub_output_.publish (ros_ptr(output.makeShared ()));
     return;
   }
 
@@ -126,13 +126,13 @@ pcl_ros::SegmentDifferences::input_target_callback (const PointCloudConstPtr &cl
                  cloud->width * cloud->height, pcl::getFieldsList (*cloud).c_str (), fromPCL(cloud->header).stamp.toSec (), cloud->header.frame_id.c_str (), pnh_->resolveName ("input").c_str (),
                  cloud_target->width * cloud_target->height, pcl::getFieldsList (*cloud_target).c_str (), fromPCL(cloud_target->header).stamp.toSec (), cloud_target->header.frame_id.c_str (), pnh_->resolveName ("target").c_str ());
 
-  impl_.setInputCloud (cloud);
-  impl_.setTargetCloud (cloud_target);
+  impl_.setInputCloud (pcl_ptr(cloud));
+  impl_.setTargetCloud (pcl_ptr(cloud_target));
 
   PointCloud output;
   impl_.segment (output);
 
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
   NODELET_DEBUG ("[%s::segmentAndPublish] Published PointCloud2 with %zu points and stamp %f on topic %s", getName ().c_str (),
                      output.points.size (), fromPCL(output.header).stamp.toSec (), pnh_->resolveName ("output").c_str ());
 }

--- a/pcl_ros/src/pcl_ros/surface/convex_hull.cpp
+++ b/pcl_ros/src/pcl_ros/surface/convex_hull.cpp
@@ -121,7 +121,7 @@ void
     NODELET_ERROR ("[%s::input_indices_callback] Invalid input!", getName ().c_str ());
     // Publish an empty message
     output.header = cloud->header;
-    pub_output_.publish (output.makeShared ());
+    pub_output_.publish (ros_ptr(output.makeShared ()));
     return;
   }
   // If indices are given, check if they are valid
@@ -130,7 +130,7 @@ void
     NODELET_ERROR ("[%s::input_indices_callback] Invalid indices!", getName ().c_str ());
     // Publish an empty message
     output.header = cloud->header;
-    pub_output_.publish (output.makeShared ());
+    pub_output_.publish (ros_ptr(output.makeShared ()));
     return;
   }
 
@@ -150,7 +150,7 @@ void
   if (indices)
     indices_ptr.reset (new std::vector<int> (indices->indices));
 
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
   impl_.setIndices (indices_ptr);
 
   // Estimate the feature
@@ -194,7 +194,7 @@ void
   }
   // Publish a Boost shared ptr const data
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
 }
 
 typedef pcl_ros::ConvexHull2D ConvexHull2D;

--- a/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
+++ b/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
@@ -141,7 +141,7 @@ pcl_ros::MovingLeastSquares::input_indices_callback (const PointCloudInConstPtr 
   {
     NODELET_ERROR ("[%s::input_indices_callback] Invalid input!", getName ().c_str ());
     output.header = cloud->header;
-    pub_output_.publish (output.makeShared ());
+    pub_output_.publish (ros_ptr(output.makeShared ()));
     return;
   }
   // If indices are given, check if they are valid
@@ -149,7 +149,7 @@ pcl_ros::MovingLeastSquares::input_indices_callback (const PointCloudInConstPtr 
   {
     NODELET_ERROR ("[%s::input_indices_callback] Invalid indices!", getName ().c_str ());
     output.header = cloud->header;
-    pub_output_.publish (output.makeShared ());
+    pub_output_.publish (ros_ptr(output.makeShared ()));
     return;
   }
 
@@ -166,7 +166,7 @@ pcl_ros::MovingLeastSquares::input_indices_callback (const PointCloudInConstPtr 
   ///
 
   // Reset the indices and surface pointers
-  impl_.setInputCloud (cloud);
+  impl_.setInputCloud (pcl_ptr(cloud));
 
   IndicesPtr indices_ptr;
   if (indices)
@@ -182,9 +182,9 @@ pcl_ros::MovingLeastSquares::input_indices_callback (const PointCloudInConstPtr 
   // Publish a Boost shared ptr const data
   // Enforce that the TF frame and the timestamp are copied
   output.header = cloud->header;
-  pub_output_.publish (output.makeShared ());
+  pub_output_.publish (ros_ptr(output.makeShared ()));
   normals->header = cloud->header;
-  pub_normals_.publish (normals);
+  pub_normals_.publish (ros_ptr(normals));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/tools/pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/pointcloud_to_pcd.cpp
@@ -78,7 +78,7 @@ class PointCloudToPCD
     ////////////////////////////////////////////////////////////////////////////////
     // Callback
     void
-      cloud_cb (const pcl::PCLPointCloud2::ConstPtr& cloud)
+      cloud_cb (const boost::shared_ptr<const pcl::PCLPointCloud2>& cloud)
     {
       if ((cloud->width * cloud->height) == 0)
         return;


### PR DESCRIPTION
PCL 1.11 changes it's internal shared pointer from `boost::shared_ptr` to `std::shared_ptr`

This PR addresses the few locations where compiling against PCL 1.11 would fail

PS: Once merged, we can test PCL for the release against melodic and possibly kinetic