### PR TITLE
Add workaround for deprecated filter functions

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -4,10 +4,10 @@ project(pcl_ros)
 add_compile_options(-std=c++14)
 
 ## Find system dependencies
+find_package(PCL REQUIRED COMPONENTS core features filters io segmentation surface)
 find_package(cmake_modules REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system filesystem thread)
 find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED COMPONENTS core features filters io segmentation surface)
 
 if(NOT "${PCL_LIBRARIES}" STREQUAL "")
   # For debian: https://github.com/ros-perception/perception_pcl/issues/139

--- a/pcl_ros/src/pcl_ros/filters/passthrough.cpp
+++ b/pcl_ros/src/pcl_ros/filters/passthrough.cpp
@@ -95,11 +95,19 @@ pcl_ros::PassThrough::config_callback (pcl_ros::FilterConfig &config, uint32_t /
   }
 
   // Check the current value for the negative flag
+#if PCL_VERSION_COMPARE(<, 1, 10, 0)
   if (impl_.getFilterLimitsNegative () != config.filter_limit_negative)
+#else
+  if (impl_.getNegative () != config.filter_limit_negative)
+#endif
   {
     NODELET_DEBUG ("[%s::config_callback] Setting the filter negative flag to: %s.", getName ().c_str (), config.filter_limit_negative ? "true" : "false");
     // Call the virtual method in the child
+#if PCL_VERSION_COMPARE(<, 1, 10, 0)
     impl_.setFilterLimitsNegative (config.filter_limit_negative);
+#else
+    impl_.setNegative (config.filter_limit_negative);
+#endif
   }
 
   // The following parameters are updated automatically for all PCL_ROS Nodelet Filters as they are inexistent in PCL


### PR DESCRIPTION
See also:
https://github.com/PointCloudLibrary/pcl/commit/f26c6fcc24386c29213b62423710c8927cbe1d21
https://github.com/PointCloudLibrary/pcl/commit/630627b2accad395f80bc6518f8dcd94a1f9ad31