### PR TITLE
link pcl library to targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - VERBOSE_OUTPUT=true
     - VERBOSE_TESTS=true
   matrix:
-    - ROS_DISTRO=foxy OS_NAME=ubuntu OS_CODE_NAME=bionic
+    - ROS_DISTRO=foxy OS_NAME=ubuntu OS_CODE_NAME=focal
 
 install:
   - git clone --branch master --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci

--- a/pcl_conversions/CMakeLists.txt
+++ b/pcl_conversions/CMakeLists.txt
@@ -45,7 +45,7 @@ if(BUILD_TESTING)
   ament_target_dependencies(${PROJECT_NAME}-test
     ${dependencies}
   )
-  target_link_libraries(${PROJECT_NAME}-test ${Boost_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}-test ${Boost_LIBRARIES} ${PCL_LIBRARIES})
 endif()
 
 ament_export_include_directories(include)


### PR DESCRIPTION
fix for #286 

using ```target_link_libraries()``` for linking pcl_libraries with targets as described in pcl docs here https://pcl.readthedocs.io/projects/tutorials/en/latest/using_pcl_pcl_config.html#using-pcl-pcl-config.