### PR TITLE
Add missing include for new PCL versions

### DIFF
--- a/pcl_ros/include/pcl_ros/surface/moving_least_squares.h
+++ b/pcl_ros/include/pcl_ros/surface/moving_least_squares.h
@@ -42,6 +42,7 @@
 
 // PCL includes
 #include <pcl/surface/mls.h>
+#include <pcl/kdtree/kdtree.h> // for KdTree
 
 // Dynamic reconfigure
 #include <dynamic_reconfigure/server.h>


### PR DESCRIPTION
After this change https://github.com/PointCloudLibrary/pcl/commit/6df3e602a72ea16657f901c9a6911d95b263ba08#diff-24324a084e511502d7f34054ec31b353L50, an explicit include for KdTree is needed.
It was formerly a transitive include via pcl/surface/mls.h - pcl/search/pcl_search.h - pcl/search/kdtree.h - pcl/kdtree/kdtree_flann.h.