### PR TITLE
Deprecate use_polynomial_fit

### DIFF
--- a/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
+++ b/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
@@ -212,7 +212,22 @@ pcl_ros::MovingLeastSquares::config_callback (MLSConfig &config, uint32_t /*leve
   {
     use_polynomial_fit_ = config.use_polynomial_fit;
     NODELET_DEBUG ("[config_callback] Setting the use_polynomial_fit flag to: %d.", use_polynomial_fit_);
+#if PCL_VERSION_COMPARE(<, 1, 9, 0)
     impl_.setPolynomialFit (use_polynomial_fit_);
+#else
+    if (use_polynomial_fit_)
+    {
+      NODELET_WARN ("[config_callback] use_polynomial_fit is deprecated, use polynomial_order instead!");
+      if (impl_.getPolynomialOrder () < 2)
+      {
+        impl_.setPolynomialOrder (2);
+      }
+    }
+    else
+    {
+      impl_.setPolynomialOrder (0);
+    }
+#endif
   }
   if (polynomial_order_ != config.polynomial_order)
   {


### PR DESCRIPTION
The pcl function setPolynomialFit is deprecated, setPolynomialOrder should be used instead