### PR TITLE
Change conversions of Vertices for new PCL versions

### DIFF
--- a/pcl_conversions/include/pcl_conversions/pcl_conversions.h
+++ b/pcl_conversions/include/pcl_conversions/pcl_conversions.h
@@ -350,10 +350,25 @@ namespace pcl_conversions {
 
   /** pcl::Vertices <=> pcl_msgs::Vertices **/
 
+  namespace internal
+  {
+    template <class T>
+    inline void move(std::vector<T> &a, std::vector<T> &b)
+    {
+      b.swap(a);
+    }
+
+    template <class T1, class T2>
+    inline void move(std::vector<T1> &a, std::vector<T2> &b)
+    {
+      b.assign(a.cbegin(), a.cend());
+    }
+  }
+
   inline
   void fromPCL(const pcl::Vertices &pcl_vert, pcl_msgs::Vertices &vert)
   {
-    vert.vertices = pcl_vert.vertices;
+    vert.vertices.assign(pcl_vert.vertices.cbegin(), pcl_vert.vertices.cend());
   }
 
   inline
@@ -370,7 +385,7 @@ namespace pcl_conversions {
   inline
   void moveFromPCL(pcl::Vertices &pcl_vert, pcl_msgs::Vertices &vert)
   {
-    vert.vertices.swap(pcl_vert.vertices);
+    internal::move(pcl_vert.vertices, vert.vertices);
   }
 
   inline
@@ -387,7 +402,7 @@ namespace pcl_conversions {
   inline
   void toPCL(const pcl_msgs::Vertices &vert, pcl::Vertices &pcl_vert)
   {
-    pcl_vert.vertices = vert.vertices;
+    pcl_vert.vertices.assign(vert.vertices.cbegin(), vert.vertices.cend());
   }
 
   inline
@@ -404,7 +419,7 @@ namespace pcl_conversions {
   inline
   void moveToPCL(pcl_msgs::Vertices &vert, pcl::Vertices &pcl_vert)
   {
-    pcl_vert.vertices.swap(vert.vertices);
+    internal::move(vert.vertices, pcl_vert.vertices);
   }
 
   inline


### PR DESCRIPTION
In https://github.com/PointCloudLibrary/pcl/commit/ad00c7bee2fad0391649479d90eee4461a2e74e7, the vertices field of pcl::Vertices changed from `std::vector<std::uint32_t>` to `std::vector<pcl::index_t>`, where index_t is an index type with configurable size (currently by default int). This commit makes conversions from and to pcl_msgs::Vertices possible again, moving the vector contents if possible.