### PR TITLE
Use complete namespace for traits members

### DIFF
--- a/pcl_ros/include/pcl_ros/point_cloud.h
+++ b/pcl_ros/include/pcl_ros/point_cloud.h
@@ -23,19 +23,19 @@ namespace pcl
 
       template<typename U> void operator() ()
       {
-        const char* name = traits::name<PointT, U>::value;
+        const char* name = pcl::traits::name<PointT, U>::value;
         std::uint32_t name_length = strlen(name);
         stream_.next(name_length);
         if (name_length > 0)
           memcpy(stream_.advance(name_length), name, name_length);
 
-        std::uint32_t offset = traits::offset<PointT, U>::value;
+        std::uint32_t offset = pcl::traits::offset<PointT, U>::value;
         stream_.next(offset);
 
-        std::uint8_t datatype = traits::datatype<PointT, U>::value;
+        std::uint8_t datatype = pcl::traits::datatype<PointT, U>::value;
         stream_.next(datatype);
 
-        std::uint32_t count = traits::datatype<PointT, U>::size;
+        std::uint32_t count = pcl::traits::datatype<PointT, U>::size;
         stream_.next(count);
       }
 
@@ -49,7 +49,7 @@ namespace pcl
 
       template<typename U> void operator() ()
       {
-        std::uint32_t name_length = strlen(traits::name<PointT, U>::value);
+        std::uint32_t name_length = strlen(pcl::traits::name<PointT, U>::value);
         length += name_length + 13;
       }
 


### PR DESCRIPTION
This prevents errors like this: error: ‘name’ is not a member of ‘pcl::detail::traits’; did you mean ‘pcl::traits::name’?
The error appears for newer PCL versions (everything after commit https://github.com/PointCloudLibrary/pcl/commit/d39d3d3300746b952997e5bd2742dac7482aa5ab), but this change should also be fully compatible with older PCL versions.