### PR TITLE
shared library bug fix

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(pcl_ros_tf src/transforms.cpp)
 ament_target_dependencies(pcl_ros_tf
   ${dependencies}
 )
-target_link_libraries(pcl_ros_tf ${PCL_LIBRARIES})
+target_link_libraries(pcl_ros_tf SHARED ${PCL_LIBRARIES})
 
 ### Nodelets
 #


### PR DESCRIPTION
Signed-off-by: Patrick Musau <pmusau13ster@gmail.com>

Encountered the following error:
```
/usr/bin/ld: /opt/ros/galactic/lib/libpcl_ros_tf.a(transforms.cpp.o): relocation R_X86_64_PC32 against symbol `g_rcutils_logging_initialized' can not be used when making a shared object; recompile with -fPIC
```

 when trying to address this [PR](https://github.com/ros-perception/laser_filters/pull/104/).  This PR fixes that issue.