### PR TITLE
[backport galactic] adding -fPIC compiler flag per warning suggestion (#335)

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -fPIC)
 endif()
 
 ## Find system dependencies


### PR DESCRIPTION
Backport galactic: #335
This PR fixed the error below
```
/usr/bin/ld: /home/kosuke55/workspace/install/pcl_ros/lib/libpcl_ros_tf.a(transforms.cpp.o): relocation R_X86_64_PC32 against symbol `g_rcutils_logging_initialized' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```