### PR TITLE
pcl_ros: Use vec.data() instead of &vec[0]

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(pcl_ros)
 
-set(CMAKE_VERBOSE_MAKEFILE ON)
-add_compile_options(-std=c++14)
+# CMake 3.1 added support for CMAKE_CXX_STANDARD to manage the C++ standard version
+# Use CMake C++ standard management where possible for better interoperability
+# with dependencies that export target standards and/or features
+if (${CMAKE_VERSION} VERSION_LESS "3.1")
+  add_compile_options(-std=c++14)
+else()
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 ## Find system dependencies
 find_package(PCL REQUIRED COMPONENTS core features filters io segmentation surface)

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(pcl_ros)
 
+set(CMAKE_VERBOSE_MAKEFILE ON)
 add_compile_options(-std=c++14)
 
 ## Find system dependencies

--- a/pcl_ros/include/pcl_ros/point_cloud.h
+++ b/pcl_ros/include/pcl_ros/point_cloud.h
@@ -164,7 +164,7 @@ namespace ros
         stream.next(row_step);
         uint32_t data_size = row_step * height;
         stream.next(data_size);
-        memcpy(stream.advance(data_size), &m.points[0], data_size);
+        memcpy(stream.advance(data_size), m.points.data(), data_size);
 
         uint8_t is_dense = m.is_dense;
         stream.next(is_dense);
@@ -203,7 +203,7 @@ namespace ros
         stream.next(data_size);
         assert(data_size == m.height * m.width * point_step);
         m.points.resize(m.height * m.width);
-        uint8_t* m_data = reinterpret_cast<uint8_t*>(&m.points[0]);
+        uint8_t* m_data = reinterpret_cast<uint8_t*>(m.points.data());
         // If the data layouts match, can copy a whole row in one memcpy
         if (mapping.size() == 1 &&
             mapping[0].serialized_offset == 0 &&

--- a/pcl_ros/src/transforms.cpp
+++ b/pcl_ros/src/transforms.cpp
@@ -188,7 +188,7 @@ transformPointCloud (const Eigen::Matrix4f &transform, const sensor_msgs::PointC
     out.is_dense     = in.is_dense;
     out.data.resize (in.data.size ());
     // Copy everything as it's faster than copying individual elements
-    memcpy (&out.data[0], &in.data[0], in.data.size ());
+    memcpy (out.data.data (), in.data.data (), in.data.size ());
   }
 
   Eigen::Array4i xyz_offset (in.fields[x_idx].offset, in.fields[y_idx].offset, in.fields[z_idx].offset, 0);


### PR DESCRIPTION
Update pcl_ros to use the data() member function of STL containers to
get the pointer to the underlying storage, instead of dereferencing the
zeroth element and taking its reference.  When a container is of size 0,
dereferencing element 0 with operator[]() is undefined behavior, and
will trigger assertions when features like _GLIBCXX_ASSERTIONS are
enabled.

Fixes #333.