### PR TITLE
pcl_ros: Use vec.data() instead of &vec[0] (ROS 2)

### DIFF
--- a/pcl_ros/include/pcl_ros/point_cloud.hpp
+++ b/pcl_ros/include/pcl_ros/point_cloud.hpp
@@ -255,7 +255,7 @@ struct Serializer<pcl::PointCloud<T>>
     stream.next(row_step);
     uint32_t data_size = row_step * height;
     stream.next(data_size);
-    memcpy(stream.advance(data_size), &m.points[0], data_size);
+    memcpy(stream.advance(data_size), m.points.data(), data_size);
 
     uint8_t is_dense = m.is_dense;
     stream.next(is_dense);
@@ -296,7 +296,7 @@ struct Serializer<pcl::PointCloud<T>>
     stream.next(data_size);
     assert(data_size == m.height * m.width * point_step);
     m.points.resize(m.height * m.width);
-    uint8_t * m_data = reinterpret_cast<uint8_t *>(&m.points[0]);
+    uint8_t * m_data = reinterpret_cast<uint8_t *>(m.points.data());
     // If the data layouts match, can copy a whole row in one memcpy
     if (mapping.size() == 1 &&
       mapping[0].serialized_offset == 0 &&

--- a/pcl_ros/src/transforms.cpp
+++ b/pcl_ros/src/transforms.cpp
@@ -166,7 +166,7 @@ transformPointCloud(
     out.is_dense = in.is_dense;
     out.data.resize(in.data.size());
     // Copy everything as it's faster than copying individual elements
-    memcpy(&out.data[0], &in.data[0], in.data.size());
+    memcpy(out.data.data(), in.data.data(), in.data.size());
   }
 
   Eigen::Array4i xyz_offset(in.fields[x_idx].offset, in.fields[y_idx].offset,


### PR DESCRIPTION
Update pcl_ros to use the data() member function of STL containers to
get the pointer to the underlying storage, instead of dereferencing the
zeroth element and taking its reference.  When a container is of size 0,
dereferencing element 0 with operator[]() is undefined behavior, and
will trigger assertions when features like _GLIBCXX_ASSERTIONS are
enabled.

Same fix as #346, but for ROS 2.