### PR TITLE
Install headers to include/${PROJECT_NAME}

### DIFF
--- a/pcl_conversions/CMakeLists.txt
+++ b/pcl_conversions/CMakeLists.txt
@@ -33,8 +33,8 @@ include_directories(
   ${PCL_COMMON_INCLUDE_DIRS}
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME}/
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
 )
 
 # Add gtest based cpp test target
@@ -48,6 +48,8 @@ if(BUILD_TESTING)
   target_link_libraries(${PROJECT_NAME}-test ${Boost_LIBRARIES} ${PCL_LIBRARIES})
 endif()
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+
 ament_export_dependencies(${dependencies})
 ament_package()

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -34,17 +34,15 @@ set(dependencies
   PCL
 )
 
-include_directories(
-  include
-  ${PCL_INCLUDE_DIRS}
-)
-
 ## Declare the pcl_ros_tf library
 add_library(pcl_ros_tf src/transforms.cpp)
+target_include_directories(pcl_ros_tf PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
 ament_target_dependencies(pcl_ros_tf
   ${dependencies}
 )
-target_link_libraries(pcl_ros_tf ${PCL_LIBRARIES})
 
 ### Nodelets
 #
@@ -165,7 +163,7 @@ endif()
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(
@@ -185,14 +183,18 @@ install(
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  INCLUDES DESTINATION include
 )
 
 install(DIRECTORY plugins samples
   DESTINATION share/${PROJECT_NAME})
 
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(pcl_ros_tf)
-ament_export_dependencies(${dependencies})
+
+# Export modern CMake targets
 ament_export_targets(export_pcl_ros HAS_LIBRARY_TARGET)
+
+ament_export_dependencies(${dependencies})
+
 ament_package()


### PR DESCRIPTION
Part of ros2/ros2#1150 - this installs headers to another folder to avoid include directory search order issues when overriding these packages.