### PR TITLE
Rename headers for humble

### DIFF
--- a/pcl_ros/src/pcl_ros/features/boundary.cpp
+++ b/pcl_ros/src/pcl_ros/features/boundary.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/boundary.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/fpfh.cpp
+++ b/pcl_ros/src/pcl_ros/features/fpfh.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/fpfh.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/fpfh_omp.cpp
+++ b/pcl_ros/src/pcl_ros/features/fpfh_omp.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/fpfh_omp.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/moment_invariants.cpp
+++ b/pcl_ros/src/pcl_ros/features/moment_invariants.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/moment_invariants.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/normal_3d.cpp
+++ b/pcl_ros/src/pcl_ros/features/normal_3d.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/normal_3d.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/normal_3d_omp.cpp
+++ b/pcl_ros/src/pcl_ros/features/normal_3d_omp.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/normal_3d_omp.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/normal_3d_tbb.cpp
+++ b/pcl_ros/src/pcl_ros/features/normal_3d_tbb.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/normal_3d_tbb.hpp"
 
 #if defined HAVE_TBB

--- a/pcl_ros/src/pcl_ros/features/pfh.cpp
+++ b/pcl_ros/src/pcl_ros/features/pfh.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/pfh.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/principal_curvatures.cpp
+++ b/pcl_ros/src/pcl_ros/features/principal_curvatures.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/principal_curvatures.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/shot.cpp
+++ b/pcl_ros/src/pcl_ros/features/shot.cpp
@@ -34,7 +34,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/shot.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/shot_omp.cpp
+++ b/pcl_ros/src/pcl_ros/features/shot_omp.cpp
@@ -34,7 +34,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/shot_omp.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/features/vfh.cpp
+++ b/pcl_ros/src/pcl_ros/features/vfh.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/vfh.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/crop_box.cpp
+++ b/pcl_ros/src/pcl_ros/filters/crop_box.cpp
@@ -37,7 +37,7 @@
  */
 
 #include "pcl_ros/filters/crop_box.hpp"
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 bool

--- a/pcl_ros/src/pcl_ros/filters/extract_indices.cpp
+++ b/pcl_ros/src/pcl_ros/filters/extract_indices.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/filters/extract_indices.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/filters/features/boundary.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/boundary.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/boundary.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/features/fpfh.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/fpfh.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/fpfh.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/features/fpfh_omp.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/fpfh_omp.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/fpfh_omp.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/features/moment_invariants.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/moment_invariants.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/moment_invariants.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/features/normal_3d.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/normal_3d.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/normal_3d.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/features/normal_3d_omp.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/normal_3d_omp.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/normal_3d_omp.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/features/normal_3d_tbb.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/normal_3d_tbb.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/normal_3d_tbb.hpp"
 
 #if defined HAVE_TBB

--- a/pcl_ros/src/pcl_ros/filters/features/pfh.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/pfh.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/pfh.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/features/principal_curvatures.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/principal_curvatures.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/principal_curvatures.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/features/vfh.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/vfh.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/features/vfh.hpp"
 
 void

--- a/pcl_ros/src/pcl_ros/filters/passthrough.cpp
+++ b/pcl_ros/src/pcl_ros/filters/passthrough.cpp
@@ -36,7 +36,7 @@
  */
 
 #include "pcl_ros/filters/passthrough.hpp"
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 bool

--- a/pcl_ros/src/pcl_ros/filters/project_inliers.cpp
+++ b/pcl_ros/src/pcl_ros/filters/project_inliers.cpp
@@ -36,7 +36,7 @@
  */
 
 #include "pcl_ros/filters/project_inliers.hpp"
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl/common/io.h>
 #include <vector>
 

--- a/pcl_ros/src/pcl_ros/filters/radius_outlier_removal.cpp
+++ b/pcl_ros/src/pcl_ros/filters/radius_outlier_removal.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/filters/radius_outlier_removal.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/filters/statistical_outlier_removal.cpp
+++ b/pcl_ros/src/pcl_ros/filters/statistical_outlier_removal.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/filters/statistical_outlier_removal.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
+++ b/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "pcl_ros/filters/voxel_grid.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/io/bag_io.cpp
+++ b/pcl_ros/src/pcl_ros/io/bag_io.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <string>
 #include "pcl_ros/io/bag_io.hpp"
 

--- a/pcl_ros/src/pcl_ros/io/concatenate_data.cpp
+++ b/pcl_ros/src/pcl_ros/io/concatenate_data.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl/common/io.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <string>

--- a/pcl_ros/src/pcl_ros/io/concatenate_fields.cpp
+++ b/pcl_ros/src/pcl_ros/io/concatenate_fields.cpp
@@ -37,7 +37,7 @@
 
 /** \author Radu Bogdan Rusu */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl/common/io.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <vector>

--- a/pcl_ros/src/pcl_ros/io/io.cpp
+++ b/pcl_ros/src/pcl_ros/io/io.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <sensor_msgs/PointCloud2.h>
 #include <message_filters/subscriber.h>
 // #include <pcl_ros/subscriber.hpp>

--- a/pcl_ros/src/pcl_ros/io/pcd_io.cpp
+++ b/pcl_ros/src/pcl_ros/io/pcd_io.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl_ros/io/pcd_io.hpp>
 #include <string>
 

--- a/pcl_ros/src/pcl_ros/segmentation/extract_clusters.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/extract_clusters.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl/common/io.h>
 #include <pcl/PointIndices.h>
 #include <pcl_conversions/pcl_conversions.h>

--- a/pcl_ros/src/pcl_ros/segmentation/extract_polygonal_prism_data.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/extract_polygonal_prism_data.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl/common/io.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <vector>

--- a/pcl_ros/src/pcl_ros/segmentation/sac_segmentation.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/sac_segmentation.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl/common/io.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <vector>

--- a/pcl_ros/src/pcl_ros/segmentation/segment_differences.cpp
+++ b/pcl_ros/src/pcl_ros/segmentation/segment_differences.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl/common/io.h>
 #include "pcl_ros/segmentation/segment_differences.hpp"
 

--- a/pcl_ros/src/pcl_ros/surface/convex_hull.cpp
+++ b/pcl_ros/src/pcl_ros/surface/convex_hull.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl/common/io.h>
 #include <geometry_msgs/PolygonStamped.h>
 #include <vector>

--- a/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
+++ b/pcl_ros/src/pcl_ros/surface/moving_least_squares.cpp
@@ -35,7 +35,7 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <pcl/common/io.h>
 #include <vector>
 #include "pcl_ros/surface/moving_least_squares.hpp"

--- a/pcl_ros/tools/pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/pointcloud_to_pcd.cpp
@@ -42,7 +42,7 @@
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 // PCL includes
 #include <pcl/common/io.h>


### PR DESCRIPTION
Humble has standardized a lot of standard packages on using .hpp for headers. This will break on galactic, so recommend pushing this to a new humble branch (or just make sure others are aware ros2 targets humble).