### PR TITLE
Migrate convert_pointcloud_to_image to ROS 2

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -132,8 +132,19 @@ target_link_libraries(pcl_ros_tf ${PCL_LIBRARIES})
 #add_executable(convert_pcd_to_image tools/convert_pcd_to_image.cpp)
 #target_link_libraries(convert_pcd_to_image ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${PCL_LIBRARIES})
 #
-#add_executable(convert_pointcloud_to_image tools/convert_pointcloud_to_image.cpp)
-#target_link_libraries(convert_pointcloud_to_image ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${PCL_LIBRARIES})
+add_executable(convert_pointcloud_to_image tools/convert_pointcloud_to_image.cpp)
+target_link_libraries(convert_pointcloud_to_image ${PCL_LIBRARIES})
+target_include_directories(convert_pointcloud_to_image PUBLIC
+  ${PCL_INCLUDE_DIRS})
+ament_target_dependencies(convert_pointcloud_to_image
+  ${dependencies})
+
+### Install
+
+install(TARGETS convert_pointcloud_to_image pcl_ros_tf
+  DESTINATION lib/${PROJECT_NAME}
+)
+
 #
 ### Downloads
 #

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -25,7 +25,7 @@
   <author email="julius@kammerl.de">Julius Kammerl</author>
   <author email="william@osrfoundation.org">William Woodall</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <depend>eigen</depend>
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>

--- a/pcl_ros/tools/convert_pointcloud_to_image.cpp
+++ b/pcl_ros/tools/convert_pointcloud_to_image.cpp
@@ -82,6 +82,8 @@ public:
     image_pub_ = this->create_publisher<sensor_msgs::msg::Image>(image_topic_, 30);
 
     // print some info about the node
+    // FIXME!
+    // Foxy doesn't have resolve_topic_name(), newer versions can use this to resolve remaps
     // std::string r_ct = this->get_node_topics_interface()->resolve_topic_name(cloud_topic_);
     // std::string r_it = this->get_node_topics_interface()->resolve_topic_name(image_topic_);
     std::string r_ct = cloud_topic_;

--- a/pcl_ros/tools/convert_pointcloud_to_image.cpp
+++ b/pcl_ros/tools/convert_pointcloud_to_image.cpp
@@ -49,6 +49,8 @@
 #include <pcl_conversions/pcl_conversions.h>
 // stl stuff
 #include <string>
+// to use make_shared<>
+#include <memory>
 
 class PointCloudToImage : public rclcpp::Node
 {
@@ -72,7 +74,7 @@ public:
       );
     }
   }
-  PointCloudToImage(const std::string name)
+  explicit PointCloudToImage(const std::string name)
   : Node(name), cloud_topic_("input"), image_topic_("output")
   {
     this->sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
@@ -103,7 +105,9 @@ private:
 int
 main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);                                                                     // this loads up the node
-  rclcpp::spin(std::make_shared<PointCloudToImage>("convert_pointcloud_to_image"));             // where she stops nobody knows
+  rclcpp::init(argc, argv);  // this loads up the node
+  rclcpp::spin(
+    std::make_shared<PointCloudToImage>("convert_pointcloud_to_image")
+  );  // where she stops nobody knows
   return 0;
 }


### PR DESCRIPTION
This PR aims to migrate the code of `convert_ponintcloud_to_image` to the ROS 2 API

Most of the changes are pretty straightforward, I think it would be interesting to think about creating a component to perform [node composition](https://docs.ros.org/en/foxy/Concepts/About-Composition.html) so it would be possible to integrate it with existing data pipeline in ROS 2 and take advantage of zero-copy transport, but this discussion is beyond the scope of this PR.

A important technical debt is that there is no method to resolve remapped topics in foxy (see https://github.com/ros2/rclcpp/pull/1410 for their implementation in galactic), so the log message doesn't display the same information as before. The version that would work in newer versions of ROS is present in comment form, so it is possible to just uncomment those when merging to the main branch.