### PR TITLE
Add boost include, missing in upcoming PCL versions

### DIFF
--- a/pcl_ros/include/pcl_ros/point_cloud.h
+++ b/pcl_ros/include/pcl_ros/point_cloud.h
@@ -8,6 +8,7 @@
 #include <pcl/conversions.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <sensor_msgs/PointCloud2.h>
+#include <boost/foreach.hpp> // for BOOST_FOREACH
 #include <boost/mpl/size.hpp>
 #include <boost/ref.hpp>
 #include <boost/thread/mutex.hpp>


### PR DESCRIPTION
Was removed in pcl/conversions.h here: https://github.com/PointCloudLibrary/pcl/commit/292593abd3b69af315c7fe3379363bdce7800d5a