### PR TITLE
Avoid redundant boost::make_shared copy in pcl_ros::Publisher<PointT>

### DIFF
--- a/pcl_ros/include/pcl_ros/publisher.hpp
+++ b/pcl_ros/include/pcl_ros/publisher.hpp
@@ -114,9 +114,9 @@ public:
   publish(const pcl::PointCloud<PointT> & point_cloud) const
   {
     // Fill point cloud binary data
-    sensor_msgs::PointCloud2 msg;
-    pcl::toROSMsg(point_cloud, msg);
-    pub_.publish(boost::make_shared<const sensor_msgs::PointCloud2>(msg));
+    sensor_msgs::PointCloud2::Ptr msg_ptr(new sensor_msgs::PointCloud2);
+    pcl::toROSMsg(point_cloud, *msg_ptr);
+    pub_.publish(msg_ptr);
   }
 };
 


### PR DESCRIPTION
`boost make_shared` is actually making a copy. This PR introduces the `sensor_msgs::PointCloud2` as pointer directly so that it doesn't need a `boost::make_shared` convertsion to pointer anymore.