### PR TITLE
Add logic for missing pcl/point_traits.h in newer PCL versions

### DIFF
--- a/pcl_ros/include/pcl_ros/point_cloud.hpp
+++ b/pcl_ros/include/pcl_ros/point_cloud.hpp
@@ -44,11 +44,15 @@
 
 #include <ros/ros.h>
 #include <pcl/point_cloud.h>
+#include <pcl/pcl_config.h> // for PCL_VERSION_COMPARE
+#if PCL_VERSION_COMPARE(>=, 1, 11, 0)
+#include <pcl/type_traits.h>
+#else
 #include <pcl/point_traits.h>
+#endif // PCL_VERSION_COMPARE(>=, 1, 11, 0)
 #include <pcl/for_each_type.h>
 #include <pcl/conversions.h>
 #if ROS_POINTER_COMPATIBILITY_IMPLEMENTED
-#include <pcl/pcl_config.h>
 #if PCL_VERSION_COMPARE(>=, 1, 11, 0)
 #include <pcl/memory.h>
 #elif PCL_VERSION_COMPARE(>=, 1, 10, 0)


### PR DESCRIPTION
point_traits.h is no longer available, starting with PCL 1.13.0. Since PCL 1.11.0, type_traits.h should be used instead.

These are the same changes as in https://github.com/ros-perception/perception_pcl/pull/381 , but for ros2.