### PR TITLE
use modular pcl dependencies for bloom

### DIFF
--- a/pcl_conversions/package.xml
+++ b/pcl_conversions/package.xml
@@ -21,13 +21,17 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libpcl-all-dev</build_depend>
+
   <depend>eigen</depend>
-  <depend>libpcl-all-dev</depend>
   <depend>message_filters</depend>
   <depend>pcl_msgs</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+
+  <exec_depend>libpcl-common</exec_depend>
+  <exec_depend>libpcl-io</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -26,8 +26,10 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>libpcl-all-dev</build_depend>
+
   <depend>eigen</depend>
-  <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
@@ -36,6 +38,13 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+
+  <exec_depend>libpcl-common</exec_depend>
+  <exec_depend>libpcl-features</exec_depend>
+  <exec_depend>libpcl-filters</exec_depend>
+  <exec_depend>libpcl-io</exec_depend>
+  <exec_depend>libpcl-segmentation</exec_depend>
+  <exec_depend>libpcl-surface</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Now that rosdep has [rules for the modular debian and ubuntu PCL packages](https://github.com/ros/rosdistro/pull/35289), those should be used here.

This doesn't make a big difference for a rosdep + colcon workflow, but it makes a _big_ difference for the bloomed debian packages. This is because `libpcl-dev` pulls in all kinds of things, including GUI tools, java, you name it. So it should only be pulled in as a build dependency (to get the headers) and then at runtime we should just pull in the .so's we need with the modular packages.

Note that for platforms that don't have modular pcl packages, these rosdep rules point to the regular pcl packages anyway, so this shouldn't break anything for them.