### PR TITLE
Adding separate leaf sizes for each axis in the VoxelGrid filter

### DIFF
--- a/pcl_ros/cfg/VoxelGrid.cfg
+++ b/pcl_ros/cfg/VoxelGrid.cfg
@@ -13,7 +13,11 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator ()
 # def add (self, name, paramtype, level, description, default = None, min = None, max = None, edit_method = ""):
 gen.add ("leaf_size", double_t, 0, "The size of a leaf (on x,y,z) used for downsampling.", 0.01, 0, 1.0)
+gen.add ("leaf_size_x", double_t, 0, "The size of a leaf (on x) used for downsampling. If negative, leaf_size is used instead.", -1.0, -1.0, 1.0)
+gen.add ("leaf_size_y", double_t, 0, "The size of a leaf (on y) used for downsampling. If negative, leaf_size is used instead.", -1.0, -1.0, 1.0)
+gen.add ("leaf_size_z", double_t, 0, "The size of a leaf (on z) used for downsampling. If negative, leaf_size is used instead.", -1.0, -1.0, 1.0)
 gen.add ("min_points_per_voxel", int_t, 0, "The minimum number of points required for a voxel to be used.", 1, 1, 100000)
+
 add_common_parameters (gen)
 
 exit (gen.generate (PACKAGE, "pcl_ros", "VoxelGrid"))

--- a/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
+++ b/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
@@ -74,14 +74,17 @@ pcl_ros::VoxelGrid::config_callback (pcl_ros::VoxelGridConfig &config, uint32_t 
   boost::mutex::scoped_lock lock (mutex_);
 
   Eigen::Vector3f leaf_size = impl_.getLeafSize ();
+  Eigen::Vector3f config_leaf_size;
 
-  if (leaf_size[0] != config.leaf_size)
-  {
-    leaf_size.setConstant (config.leaf_size);
-    NODELET_DEBUG ("[config_callback] Setting the downsampling leaf size to: %f.", leaf_size[0]);
-    impl_.setLeafSize (leaf_size[0], leaf_size[1], leaf_size[2]);
+  config_leaf_size[0] = (config.leaf_size_x >= 0.0 ? config.leaf_size_x : config.leaf_size);
+  config_leaf_size[1] = (config.leaf_size_y >= 0.0 ? config.leaf_size_y : config.leaf_size);
+  config_leaf_size[2] = (config.leaf_size_z >= 0.0 ? config.leaf_size_z : config.leaf_size);
+
+  if (leaf_size != config_leaf_size) {
+    NODELET_DEBUG("[config_callback] Setting the downsampling leaf size to: (%f, %f, %f).",
+      config_leaf_size[0], config_leaf_size[1], config_leaf_size[2]);
+    impl_.setLeafSize(config_leaf_size[0], config_leaf_size[1], config_leaf_size[2]);
   }
-  
   unsigned int minPointsPerVoxel = impl_.getMinimumPointsNumberPerVoxel ();
   if (minPointsPerVoxel != ((unsigned int) config.min_points_per_voxel))
   {


### PR DESCRIPTION
I needed to have a different leaf size for each axis (particularly `z`), but the `VoxelGrid` filter currently assumes uniform leaf sizes. The behavior here defaults to the current behavior, but optionally allows for each axis leaf size to be overridden.