### PR TITLE
Migrate four point cloud filters in the ROS2 version of pcl_ros

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -88,7 +88,7 @@ add_library(pcl_ros_filters SHARED
   src/pcl_ros/filters/project_inliers.cpp
 #  src/pcl_ros/filters/radius_outlier_removal.cpp
 #  src/pcl_ros/filters/statistical_outlier_removal.cpp
-#  src/pcl_ros/filters/voxel_grid.cpp
+  src/pcl_ros/filters/voxel_grid.cpp
 #  src/pcl_ros/filters/crop_box.cpp
 )
 target_link_libraries(pcl_ros_filters pcl_ros_tf ${PCL_LIBRARIES})
@@ -104,6 +104,10 @@ rclcpp_components_register_node(pcl_ros_filters
 rclcpp_components_register_node(pcl_ros_filters
   PLUGIN "pcl_ros::ProjectInliers"
   EXECUTABLE filter_project_inliers_node
+)
+rclcpp_components_register_node(pcl_ros_filters
+  PLUGIN "pcl_ros::VoxelGrid"
+  EXECUTABLE filter_voxel_grid_node
 )
 class_loader_hide_library_symbols(pcl_ros_filters)
 #

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -86,7 +86,7 @@ add_library(pcl_ros_filters SHARED
   src/pcl_ros/filters/filter.cpp
   src/pcl_ros/filters/passthrough.cpp
   src/pcl_ros/filters/project_inliers.cpp
-#  src/pcl_ros/filters/radius_outlier_removal.cpp
+  src/pcl_ros/filters/radius_outlier_removal.cpp
 #  src/pcl_ros/filters/statistical_outlier_removal.cpp
   src/pcl_ros/filters/voxel_grid.cpp
   src/pcl_ros/filters/crop_box.cpp
@@ -112,6 +112,10 @@ rclcpp_components_register_node(pcl_ros_filters
 rclcpp_components_register_node(pcl_ros_filters
   PLUGIN "pcl_ros::CropBox"
   EXECUTABLE filter_crop_box_node
+)
+rclcpp_components_register_node(pcl_ros_filters
+  PLUGIN "pcl_ros::RadiusOutlierRemoval"
+  EXECUTABLE filter_radius_outlier_removal_node
 )
 class_loader_hide_library_symbols(pcl_ros_filters)
 #

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -87,7 +87,7 @@ add_library(pcl_ros_filters SHARED
   src/pcl_ros/filters/passthrough.cpp
   src/pcl_ros/filters/project_inliers.cpp
   src/pcl_ros/filters/radius_outlier_removal.cpp
-#  src/pcl_ros/filters/statistical_outlier_removal.cpp
+  src/pcl_ros/filters/statistical_outlier_removal.cpp
   src/pcl_ros/filters/voxel_grid.cpp
   src/pcl_ros/filters/crop_box.cpp
 )
@@ -116,6 +116,10 @@ rclcpp_components_register_node(pcl_ros_filters
 rclcpp_components_register_node(pcl_ros_filters
   PLUGIN "pcl_ros::RadiusOutlierRemoval"
   EXECUTABLE filter_radius_outlier_removal_node
+)
+rclcpp_components_register_node(pcl_ros_filters
+  PLUGIN "pcl_ros::StatisticalOutlierRemoval"
+  EXECUTABLE filter_statistical_outlier_removal_node
 )
 class_loader_hide_library_symbols(pcl_ros_filters)
 #

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -89,7 +89,7 @@ add_library(pcl_ros_filters SHARED
 #  src/pcl_ros/filters/radius_outlier_removal.cpp
 #  src/pcl_ros/filters/statistical_outlier_removal.cpp
   src/pcl_ros/filters/voxel_grid.cpp
-#  src/pcl_ros/filters/crop_box.cpp
+  src/pcl_ros/filters/crop_box.cpp
 )
 target_link_libraries(pcl_ros_filters pcl_ros_tf ${PCL_LIBRARIES})
 ament_target_dependencies(pcl_ros_filters ${dependencies})
@@ -108,6 +108,10 @@ rclcpp_components_register_node(pcl_ros_filters
 rclcpp_components_register_node(pcl_ros_filters
   PLUGIN "pcl_ros::VoxelGrid"
   EXECUTABLE filter_voxel_grid_node
+)
+rclcpp_components_register_node(pcl_ros_filters
+  PLUGIN "pcl_ros::CropBox"
+  EXECUTABLE filter_crop_box_node
 )
 class_loader_hide_library_symbols(pcl_ros_filters)
 #

--- a/pcl_ros/include/pcl_ros/filters/crop_box.hpp
+++ b/pcl_ros/include/pcl_ros/filters/crop_box.hpp
@@ -61,8 +61,8 @@ protected:
     */
   inline void
   filter(
-    const PointCloud2::ConstPtr & input, const IndicesPtr & indices,
-    PointCloud2 & output)
+    const PointCloud2::ConstSharedPtr & input, const IndicesPtr & indices,
+    PointCloud2 & output) override
   {
     std::lock_guard<std::mutex> lock(mutex_);
     pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);

--- a/pcl_ros/include/pcl_ros/filters/radius_outlier_removal.hpp
+++ b/pcl_ros/include/pcl_ros/filters/radius_outlier_removal.hpp
@@ -42,9 +42,6 @@
 #include <pcl/filters/radius_outlier_removal.h>
 #include "pcl_ros/filters/filter.hpp"
 
-// Dynamic reconfigure
-#include "pcl_ros/RadiusOutlierRemovalConfig.hpp"
-
 namespace pcl_ros
 {
 /** \brief @b RadiusOutlierRemoval is a simple filter that removes outliers if the number of neighbors in a certain
@@ -55,9 +52,6 @@ namespace pcl_ros
 class RadiusOutlierRemoval : public Filter
 {
 protected:
-  /** \brief Pointer to a dynamic reconfigure service. */
-  boost::shared_ptr<dynamic_reconfigure::Server<pcl_ros::RadiusOutlierRemovalConfig>> srv_;
-
   /** \brief Call the actual filter.
     * \param input the input point cloud dataset
     * \param indices the input set of indices to use from \a input
@@ -65,9 +59,10 @@ protected:
     */
   inline void
   filter(
-    const PointCloud2::ConstPtr & input, const IndicesPtr & indices,
-    PointCloud2 & output)
+    const PointCloud2::ConstSharedPtr & input, const IndicesPtr & indices,
+    PointCloud2 & output) override
   {
+    std::lock_guard<std::mutex> lock(mutex_);
     pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
     pcl_conversions::toPCL(*(input), *(pcl_input));
     impl_.setInputCloud(pcl_input);
@@ -77,17 +72,13 @@ protected:
     pcl_conversions::moveFromPCL(pcl_output, output);
   }
 
-  /** \brief Child initialization routine.
-    * \param nh ROS node handle
-    * \param has_service set to true if the child has a Dynamic Reconfigure service
+  /** \brief Parameter callback
+    * \param params parameter values to set
     */
-  virtual inline bool child_init(ros::NodeHandle & nh, bool & has_service);
+  rcl_interfaces::msg::SetParametersResult
+  config_callback(const std::vector<rclcpp::Parameter> & params);
 
-  /** \brief Dynamic reconfigure callback
-    * \param config the config object
-    * \param level the dynamic reconfigure level
-    */
-  void config_callback(pcl_ros::RadiusOutlierRemovalConfig & config, uint32_t level);
+  OnSetParametersCallbackHandle::SharedPtr callback_handle_;
 
 private:
   /** \brief The PCL filter implementation used. */
@@ -95,6 +86,8 @@ private:
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit RadiusOutlierRemoval(const rclcpp::NodeOptions & options);
 };
 }  // namespace pcl_ros
 

--- a/pcl_ros/include/pcl_ros/filters/statistical_outlier_removal.hpp
+++ b/pcl_ros/include/pcl_ros/filters/statistical_outlier_removal.hpp
@@ -42,9 +42,6 @@
 #include <pcl/filters/statistical_outlier_removal.h>
 #include "pcl_ros/filters/filter.hpp"
 
-// Dynamic reconfigure
-#include "pcl_ros/StatisticalOutlierRemovalConfig.hpp"
-
 namespace pcl_ros
 {
 /** \brief @b StatisticalOutlierRemoval uses point neighborhood statistics to filter outlier data. For more
@@ -61,9 +58,6 @@ namespace pcl_ros
 class StatisticalOutlierRemoval : public Filter
 {
 protected:
-  /** \brief Pointer to a dynamic reconfigure service. */
-  boost::shared_ptr<dynamic_reconfigure::Server<pcl_ros::StatisticalOutlierRemovalConfig>> srv_;
-
   /** \brief Call the actual filter.
     * \param input the input point cloud dataset
     * \param indices the input set of indices to use from \a input
@@ -71,10 +65,10 @@ protected:
     */
   inline void
   filter(
-    const PointCloud2::ConstPtr & input, const IndicesPtr & indices,
-    PointCloud2 & output)
+    const PointCloud2::ConstSharedPtr & input, const IndicesPtr & indices,
+    PointCloud2 & output) override
   {
-    boost::mutex::scoped_lock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
     pcl_conversions::toPCL(*(input), *(pcl_input));
     impl_.setInputCloud(pcl_input);
@@ -84,17 +78,13 @@ protected:
     pcl_conversions::moveFromPCL(pcl_output, output);
   }
 
-  /** \brief Child initialization routine.
-    * \param nh ROS node handle
-    * \param has_service set to true if the child has a Dynamic Reconfigure service
+  /** \brief Parameter callback
+    * \param params parameter values to set
     */
-  bool child_init(ros::NodeHandle & nh, bool & has_service);
+  rcl_interfaces::msg::SetParametersResult
+  config_callback(const std::vector<rclcpp::Parameter> & params);
 
-  /** \brief Dynamic reconfigure callback
-    * \param config the config object
-    * \param level the dynamic reconfigure level
-    */
-  void config_callback(pcl_ros::StatisticalOutlierRemovalConfig & config, uint32_t level);
+  OnSetParametersCallbackHandle::SharedPtr callback_handle_;
 
 private:
   /** \brief The PCL filter implementation used. */
@@ -102,6 +92,8 @@ private:
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit StatisticalOutlierRemoval(const rclcpp::NodeOptions & options);
 };
 }  // namespace pcl_ros
 

--- a/pcl_ros/include/pcl_ros/filters/voxel_grid.hpp
+++ b/pcl_ros/include/pcl_ros/filters/voxel_grid.hpp
@@ -42,9 +42,6 @@
 #include <pcl/filters/voxel_grid.h>
 #include "pcl_ros/filters/filter.hpp"
 
-// Dynamic reconfigure
-#include "pcl_ros/VoxelGridConfig.hpp"
-
 namespace pcl_ros
 {
 /** \brief @b VoxelGrid assembles a local 3D grid over a given PointCloud, and downsamples + filters the data.
@@ -53,38 +50,42 @@ namespace pcl_ros
 class VoxelGrid : public Filter
 {
 protected:
-  /** \brief Pointer to a dynamic reconfigure service. */
-  boost::shared_ptr<dynamic_reconfigure::Server<pcl_ros::VoxelGridConfig>> srv_;
-
-  /** \brief The PCL filter implementation used. */
-  pcl::VoxelGrid<pcl::PCLPointCloud2> impl_;
 
   /** \brief Call the actual filter.
     * \param input the input point cloud dataset
     * \param indices the input set of indices to use from \a input
     * \param output the resultant filtered dataset
     */
-  virtual void
+  inline void
   filter(
-    const PointCloud2::ConstPtr & input, const IndicesPtr & indices,
-    PointCloud2 & output);
+    const PointCloud2::ConstSharedPtr & input, const IndicesPtr & indices,
+    PointCloud2 & output) override {
+      std::lock_guard<std::mutex> lock(mutex_);
+      pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
+      pcl_conversions::toPCL(*(input), *(pcl_input));
+      impl_.setInputCloud(pcl_input);
+      impl_.setIndices(indices);
+      pcl::PCLPointCloud2 pcl_output;
+      impl_.filter(pcl_output);
+      pcl_conversions::moveFromPCL(pcl_output, output);
+  }
 
-  /** \brief Child initialization routine.
-    * \param nh ROS node handle
-    * \param has_service set to true if the child has a Dynamic Reconfigure service
+  /** \brief Parameter callback
+    * \param params parameter values to set
     */
-  bool
-  child_init(ros::NodeHandle & nh, bool & has_service);
+  rcl_interfaces::msg::SetParametersResult
+  config_callback(const std::vector<rclcpp::Parameter> & params);
 
-  /** \brief Dynamic reconfigure callback
-    * \param config the config object
-    * \param level the dynamic reconfigure level
-    */
-  void
-  config_callback(pcl_ros::VoxelGridConfig & config, uint32_t level);
+  OnSetParametersCallbackHandle::SharedPtr callback_handle_;
+
+private:
+  /** \brief The PCL filter implementation used. */
+  pcl::VoxelGrid<pcl::PCLPointCloud2> impl_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit VoxelGrid(const rclcpp::NodeOptions & options);
 };
 }  // namespace pcl_ros
 

--- a/pcl_ros/src/pcl_ros/filters/crop_box.cpp
+++ b/pcl_ros/src/pcl_ros/filters/crop_box.cpp
@@ -37,86 +37,80 @@
  */
 
 #include "pcl_ros/filters/crop_box.hpp"
-#include <pluginlib/class_list_macros.h>
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl_ros::CropBox::child_init(ros::NodeHandle & nh, bool & has_service)
+pcl_ros::CropBox::CropBox(const rclcpp::NodeOptions & options)
+: Filter("CropBoxNode", options)
 {
-  // Enable the dynamic reconfigure service
-  has_service = true;
-  srv_ = boost::make_shared<dynamic_reconfigure::Server<pcl_ros::CropBoxConfig>>(nh);
-  dynamic_reconfigure::Server<pcl_ros::CropBoxConfig>::CallbackType f = boost::bind(
-    &CropBox::config_callback, this, _1, _2);
-  srv_->setCallback(f);
+  use_frame_params();
+  std::vector<std::string> param_names = add_common_params();
 
-  return true;
+  callback_handle_ =
+    add_on_set_parameters_callback(
+    std::bind(
+      &CropBox::config_callback, this,
+      std::placeholders::_1));
+
+  config_callback(get_parameters(param_names));
+  // TODO(daisukes): lazy subscription after rclcpp#2060
+  subscribe();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-void
-pcl_ros::CropBox::config_callback(pcl_ros::CropBoxConfig & config, uint32_t level)
+
+rcl_interfaces::msg::SetParametersResult
+pcl_ros::CropBox::config_callback(const std::vector<rclcpp::Parameter> & params)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
   Eigen::Vector4f min_point, max_point;
   min_point = impl_.getMin();
   max_point = impl_.getMax();
 
-  Eigen::Vector4f new_min_point, new_max_point;
-  new_min_point << config.min_x, config.min_y, config.min_z, 0.0;
-  new_max_point << config.max_x, config.max_y, config.max_z, 0.0;
-
-  // Check the current values for minimum point
-  if (min_point != new_min_point) {
-    NODELET_DEBUG(
-      "[%s::config_callback] Setting the minimum point to: %f %f %f.",
-      getName().c_str(), new_min_point(0), new_min_point(1), new_min_point(2));
-    // Set the filter min point if different
-    impl_.setMin(new_min_point);
+  for (const rclcpp::Parameter & param : params) {
+    if (param.get_name() == "min_x") {
+      min_point(0) = param.as_double();
+    }
+    if (param.get_name() == "max_x") {
+      max_point(0) = param.as_double();
+    }
+    if (param.get_name() == "min_y") {
+      min_point(1) = param.as_double();
+    }
+    if (param.get_name() == "max_y") {
+      max_point(1) = param.as_double();
+    }
+    if (param.get_name() == "min_z") {
+      min_point(2) = param.as_double();
+    }
+    if (param.get_name() == "max_z") {
+      max_point(2) = param.as_double();
+    }
+    if (param.get_name() == "filter_limit_negative") {
+      // Check the current value for the negative flag
+      if (impl_.getNegative() != param.as_bool()) {
+        RCLCPP_DEBUG(
+          get_logger(), "Setting the filter negative flag to: %s.",
+          param.as_bool() ? "true" : "false");
+        // Call the virtual method in the child
+        impl_.setNegative(param.as_bool());
+      }
+    }
+    if (param.get_name() == "keep_organized") {
+      // Check the current value for keep_organized
+      if (impl_.getKeepOrganized() != param.as_bool()) {
+        RCLCPP_DEBUG(
+          get_logger(), "Setting the filter keep_organized value to: %s.",
+          param.as_bool() ? "true" : "false");
+        // Call the virtual method in the child
+        impl_.setKeepOrganized(param.as_bool());
+      }
+    }
   }
-  // Check the current values for the maximum point
-  if (max_point != new_max_point) {
-    NODELET_DEBUG(
-      "[%s::config_callback] Setting the maximum point to: %f %f %f.",
-      getName().c_str(), new_max_point(0), new_max_point(1), new_max_point(2));
-    // Set the filter max point if different
-    impl_.setMax(new_max_point);
-  }
-
-  // Check the current value for keep_organized
-  if (impl_.getKeepOrganized() != config.keep_organized) {
-    NODELET_DEBUG(
-      "[%s::config_callback] Setting the filter keep_organized value to: %s.",
-      getName().c_str(), config.keep_organized ? "true" : "false");
-    // Call the virtual method in the child
-    impl_.setKeepOrganized(config.keep_organized);
-  }
-
-  // Check the current value for the negative flag
-  if (impl_.getNegative() != config.negative) {
-    NODELET_DEBUG(
-      "[%s::config_callback] Setting the filter negative flag to: %s.",
-      getName().c_str(), config.negative ? "true" : "false");
-    // Call the virtual method in the child
-    impl_.setNegative(config.negative);
-  }
-
-  // The following parameters are updated automatically for all PCL_ROS Nodelet Filters
-  // as they are inexistent in PCL
-  if (tf_input_frame_ != config.input_frame) {
-    tf_input_frame_ = config.input_frame;
-    NODELET_DEBUG(
-      "[%s::config_callback] Setting the input TF frame to: %s.",
-      getName().c_str(), tf_input_frame_.c_str());
-  }
-  if (tf_output_frame_ != config.output_frame) {
-    tf_output_frame_ = config.output_frame;
-    NODELET_DEBUG(
-      "[%s::config_callback] Setting the output TF frame to: %s.",
-      getName().c_str(), tf_output_frame_.c_str());
-  }
+  // TODO(sloretz) constraint validation
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  return result;
 }
 
-typedef pcl_ros::CropBox CropBox;
-PLUGINLIB_EXPORT_CLASS(CropBox, nodelet::Nodelet);
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(pcl_ros::CropBox)

--- a/pcl_ros/src/pcl_ros/filters/crop_box.cpp
+++ b/pcl_ros/src/pcl_ros/filters/crop_box.cpp
@@ -106,6 +106,21 @@ pcl_ros::CropBox::config_callback(const std::vector<rclcpp::Parameter> & params)
       }
     }
   }
+
+  // Check the current values for minimum point
+  if (min_point != impl_.getMin()) {
+    RCLCPP_DEBUG(get_logger(), "Setting the minimum point to: %f %f %f.",
+      min_point(0), min_point(1), min_point(2));
+    impl_.setMin(min_point);
+  }
+  
+  // Check the current values for the maximum point
+  if (max_point != impl_.getMax()) {
+    RCLCPP_DEBUG(get_logger(), "Setting the maximum point to: %f %f %f.",
+      max_point(0), max_point(1), max_point(2));
+    impl_.setMax(max_point);
+  }
+
   // TODO(sloretz) constraint validation
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -226,20 +226,24 @@ pcl_ros::Filter::add_common_params()
   flmin_desc.name = "filter_limit_min";
   flmin_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   flmin_desc.description = "The minimum allowed field value a point will be considered from";
-  rcl_interfaces::msg::FloatingPointRange flmin_range;
-  flmin_range.from_value = -100000.0;
-  flmin_range.to_value = 100000.0;
-  flmin_desc.floating_point_range.push_back(flmin_range);
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -100000.0;
+    float_range.to_value = 100000.0;
+    flmin_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(flmin_desc.name, rclcpp::ParameterValue(0.0), flmin_desc);
 
   rcl_interfaces::msg::ParameterDescriptor flmax_desc;
   flmax_desc.name = "filter_limit_max";
   flmax_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   flmax_desc.description = "The maximum allowed field value a point will be considered from";
-  rcl_interfaces::msg::FloatingPointRange flmax_range;
-  flmax_range.from_value = -100000.0;
-  flmax_range.to_value = 100000.0;
-  flmax_desc.floating_point_range.push_back(flmax_range);
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -100000.0;
+    float_range.to_value = 100000.0;
+    flmax_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(flmax_desc.name, rclcpp::ParameterValue(1.0), flmax_desc);
 
   rcl_interfaces::msg::ParameterDescriptor flneg_desc;
@@ -273,6 +277,12 @@ pcl_ros::Filter::add_common_params()
   min_x_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   min_x_desc.description =
     "Minimum x value below which points will be removed";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -1000.0;
+    float_range.to_value = 1000.0;
+    min_x_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(min_x_desc.name, rclcpp::ParameterValue(-1.0), min_x_desc);
   
   rcl_interfaces::msg::ParameterDescriptor max_x_desc;
@@ -280,6 +290,12 @@ pcl_ros::Filter::add_common_params()
   max_x_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   max_x_desc.description =
     "Maximum x value above which points will be removed";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -1000.0;
+    float_range.to_value = 1000.0;
+    max_x_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(max_x_desc.name, rclcpp::ParameterValue(1.0), max_x_desc);
 
   rcl_interfaces::msg::ParameterDescriptor min_y_desc;
@@ -287,6 +303,12 @@ pcl_ros::Filter::add_common_params()
   min_y_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   min_y_desc.description =
     "Minimum y value below which points will be removed";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -1000.0;
+    float_range.to_value = 1000.0;
+    min_y_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(min_y_desc.name, rclcpp::ParameterValue(-1.0), min_y_desc);
   
   rcl_interfaces::msg::ParameterDescriptor max_y_desc;
@@ -294,6 +316,12 @@ pcl_ros::Filter::add_common_params()
   max_y_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   max_y_desc.description =
     "Maximum y value above which points will be removed";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -1000.0;
+    float_range.to_value = 1000.0;
+    max_y_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(max_y_desc.name, rclcpp::ParameterValue(1.0), max_y_desc);
 
   rcl_interfaces::msg::ParameterDescriptor min_z_desc;
@@ -301,6 +329,12 @@ pcl_ros::Filter::add_common_params()
   min_z_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   min_z_desc.description =
     "Minimum z value below which points will be removed";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -1000.0;
+    float_range.to_value = 1000.0;
+    min_z_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(min_z_desc.name, rclcpp::ParameterValue(-1.0), min_z_desc);
   
   rcl_interfaces::msg::ParameterDescriptor max_z_desc;
@@ -308,6 +342,12 @@ pcl_ros::Filter::add_common_params()
   max_z_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   max_z_desc.description =
     "Maximum z value above which points will be removed";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -1000.0;
+    float_range.to_value = 1000.0;
+    max_z_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(max_z_desc.name, rclcpp::ParameterValue(1.0), max_z_desc);
 
   // filter: RadiusOutlierRemoval
@@ -317,6 +357,12 @@ pcl_ros::Filter::add_common_params()
   min_neighbors_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
   min_neighbors_desc.description =
     "The number of neighbors that need to be present in order to be classified as an inlier.";
+  {
+    rcl_interfaces::msg::IntegerRange int_range;
+    int_range.from_value = 0;
+    int_range.to_value = 1000;
+    min_neighbors_desc.integer_range.push_back(int_range);
+  }
   declare_parameter(min_neighbors_desc.name, rclcpp::ParameterValue(5), min_neighbors_desc);
 
   rcl_interfaces::msg::ParameterDescriptor radius_search_desc;
@@ -324,6 +370,12 @@ pcl_ros::Filter::add_common_params()
   radius_search_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   radius_search_desc.description =
     "Radius of the sphere that will determine which points are neighbors.";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = 0.0;
+    float_range.to_value = 10.0;
+    radius_search_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(radius_search_desc.name, rclcpp::ParameterValue(0.1), radius_search_desc);
 
   // filter: StatisticalOutlierRemoval
@@ -333,6 +385,12 @@ pcl_ros::Filter::add_common_params()
   mean_k_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
   mean_k_desc.description =
     "The number of points (k) to use for mean distance estimation.";
+  {
+    rcl_interfaces::msg::IntegerRange int_range;
+    int_range.from_value = 2;
+    int_range.to_value = 100;
+    mean_k_desc.integer_range.push_back(int_range);
+  }
   declare_parameter(mean_k_desc.name, rclcpp::ParameterValue(2), mean_k_desc);
 
   rcl_interfaces::msg::ParameterDescriptor stddev_desc;
@@ -341,6 +399,12 @@ pcl_ros::Filter::add_common_params()
   stddev_desc.description =
     "The standard deviation multiplier threshold. \
     All points outside the mean +- sigma * std_mul will be considered outliers.";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = 0.0;
+    float_range.to_value = 5.0;
+    stddev_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(stddev_desc.name, rclcpp::ParameterValue(0.0), stddev_desc);
 
   rcl_interfaces::msg::ParameterDescriptor negative_desc;

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -214,6 +214,8 @@ pcl_ros::Filter::use_frame_params()
 std::vector<std::string>
 pcl_ros::Filter::add_common_params()
 {
+  // filter: Passthrough
+
   rcl_interfaces::msg::ParameterDescriptor ffn_desc;
   ffn_desc.name = "filter_field_name";
   ffn_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
@@ -255,6 +257,8 @@ pcl_ros::Filter::add_common_params()
     "or removed from the PointCloud, thus potentially breaking its organized structure.";
   declare_parameter(keep_organized_desc.name, rclcpp::ParameterValue(false), keep_organized_desc);
 
+  // filter: VoxelGrid
+
   rcl_interfaces::msg::ParameterDescriptor leaf_size_desc;
   leaf_size_desc.name = "leaf_size";
   leaf_size_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
@@ -262,53 +266,51 @@ pcl_ros::Filter::add_common_params()
     "The size of a leaf (on x,y,z) used for downsampling";
   declare_parameter(leaf_size_desc.name, rclcpp::ParameterValue(0.01), leaf_size_desc);
 
+  // filter: CropBox
+
   rcl_interfaces::msg::ParameterDescriptor min_x_desc;
   min_x_desc.name = "min_x";
   min_x_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   min_x_desc.description =
     "Minimum x value below which points will be removed";
-  declare_parameter(min_x_desc.name,
-    rclcpp::ParameterValue(-1.0), min_x_desc);
+  declare_parameter(min_x_desc.name, rclcpp::ParameterValue(-1.0), min_x_desc);
   
   rcl_interfaces::msg::ParameterDescriptor max_x_desc;
   max_x_desc.name = "max_x";
   max_x_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   max_x_desc.description =
     "Maximum x value above which points will be removed";
-  declare_parameter(max_x_desc.name,
-    rclcpp::ParameterValue(1.0), max_x_desc);
+  declare_parameter(max_x_desc.name, rclcpp::ParameterValue(1.0), max_x_desc);
 
   rcl_interfaces::msg::ParameterDescriptor min_y_desc;
   min_y_desc.name = "min_y";
   min_y_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   min_y_desc.description =
     "Minimum y value below which points will be removed";
-  declare_parameter(min_y_desc.name,
-    rclcpp::ParameterValue(-1.0), min_y_desc);
+  declare_parameter(min_y_desc.name, rclcpp::ParameterValue(-1.0), min_y_desc);
   
   rcl_interfaces::msg::ParameterDescriptor max_y_desc;
   max_y_desc.name = "max_y";
   max_y_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   max_y_desc.description =
     "Maximum y value above which points will be removed";
-  declare_parameter(max_y_desc.name,
-    rclcpp::ParameterValue(1.0), max_y_desc);
+  declare_parameter(max_y_desc.name, rclcpp::ParameterValue(1.0), max_y_desc);
 
   rcl_interfaces::msg::ParameterDescriptor min_z_desc;
   min_z_desc.name = "min_z";
   min_z_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   min_z_desc.description =
     "Minimum z value below which points will be removed";
-  declare_parameter(min_z_desc.name,
-    rclcpp::ParameterValue(-1.0), min_z_desc);
+  declare_parameter(min_z_desc.name, rclcpp::ParameterValue(-1.0), min_z_desc);
   
   rcl_interfaces::msg::ParameterDescriptor max_z_desc;
   max_z_desc.name = "max_z";
   max_z_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   max_z_desc.description =
     "Maximum z value above which points will be removed";
-  declare_parameter(max_z_desc.name,
-    rclcpp::ParameterValue(1.0), max_z_desc);
+  declare_parameter(max_z_desc.name, rclcpp::ParameterValue(1.0), max_z_desc);
+
+  // filter: RadiusOutlierRemoval
 
   rcl_interfaces::msg::ParameterDescriptor min_neighbors_desc;
   min_neighbors_desc.name = "min_neighbors";
@@ -323,6 +325,30 @@ pcl_ros::Filter::add_common_params()
   radius_search_desc.description =
     "Radius of the sphere that will determine which points are neighbors.";
   declare_parameter(radius_search_desc.name, rclcpp::ParameterValue(0.1), radius_search_desc);
+
+  // filter: StatisticalOutlierRemoval
+
+  rcl_interfaces::msg::ParameterDescriptor mean_k_desc;
+  mean_k_desc.name = "mean_k";
+  mean_k_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  mean_k_desc.description =
+    "The number of points (k) to use for mean distance estimation.";
+  declare_parameter(mean_k_desc.name, rclcpp::ParameterValue(2), mean_k_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor stddev_desc;
+  stddev_desc.name = "stddev";
+  stddev_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  stddev_desc.description =
+    "The standard deviation multiplier threshold. \
+    All points outside the mean +- sigma * std_mul will be considered outliers.";
+  declare_parameter(stddev_desc.name, rclcpp::ParameterValue(0.0), stddev_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor negative_desc;
+  negative_desc.name = "negative";
+  negative_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  negative_desc.description =
+    "Set whether the inliers should be returned (true) or the outliers (false).";
+  declare_parameter(negative_desc.name, rclcpp::ParameterValue(false), negative_desc);
 
   return std::vector<std::string> {
     ffn_desc.name,
@@ -339,6 +365,9 @@ pcl_ros::Filter::add_common_params()
     max_z_desc.name,
     min_neighbors_desc.name,
     radius_search_desc.name,
+    mean_k_desc.name,
+    stddev_desc.name,
+    negative_desc.name,
   };
 }
 

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -262,13 +262,67 @@ pcl_ros::Filter::add_common_params()
     "Set the extent of a leaf, which is essentially the voxel size for accumulation.";
   declare_parameter(leaf_size_desc.name, rclcpp::ParameterValue(0.05), leaf_size_desc);
 
+  rcl_interfaces::msg::ParameterDescriptor min_x_desc;
+  min_x_desc.name = "min_x";
+  min_x_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  min_x_desc.description =
+    "Minimum x value below which points will be removed";
+  declare_parameter(min_x_desc.name,
+    rclcpp::ParameterValue(std::numeric_limits<double>::min()), min_x_desc);
+  
+  rcl_interfaces::msg::ParameterDescriptor max_x_desc;
+  max_x_desc.name = "max_x";
+  max_x_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  max_x_desc.description =
+    "Maximum x value above which points will be removed";
+  declare_parameter(max_x_desc.name,
+    rclcpp::ParameterValue(std::numeric_limits<double>::max()), max_x_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor min_y_desc;
+  min_y_desc.name = "min_y";
+  min_y_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  min_y_desc.description =
+    "Minimum y value below which points will be removed";
+  declare_parameter(min_y_desc.name,
+    rclcpp::ParameterValue(std::numeric_limits<double>::min()), min_y_desc);
+  
+  rcl_interfaces::msg::ParameterDescriptor max_y_desc;
+  max_y_desc.name = "max_y";
+  max_y_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  max_y_desc.description =
+    "Maximum y value above which points will be removed";
+  declare_parameter(max_y_desc.name,
+    rclcpp::ParameterValue(std::numeric_limits<double>::max()), max_y_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor min_z_desc;
+  min_z_desc.name = "min_z";
+  min_z_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  min_z_desc.description =
+    "Minimum z value below which points will be removed";
+  declare_parameter(min_z_desc.name,
+    rclcpp::ParameterValue(std::numeric_limits<double>::min()), min_z_desc);
+  
+  rcl_interfaces::msg::ParameterDescriptor max_z_desc;
+  max_z_desc.name = "max_z";
+  max_z_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  max_z_desc.description =
+    "Maximum z value above which points will be removed";
+  declare_parameter(max_z_desc.name,
+    rclcpp::ParameterValue(std::numeric_limits<double>::max()), max_z_desc);
+    
   return std::vector<std::string> {
     ffn_desc.name,
     flmin_desc.name,
     flmax_desc.name,
     flneg_desc.name,
     keep_organized_desc.name,
-    leaf_size_desc.name
+    leaf_size_desc.name,
+    min_x_desc.name,
+    max_x_desc.name,
+    min_y_desc.name,
+    max_y_desc.name,
+    min_z_desc.name,
+    max_z_desc.name,
   };
 }
 

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -303,7 +303,7 @@ pcl_ros::Filter::add_common_params()
   declare_parameter(leaf_size_y_desc.name, rclcpp::ParameterValue(-1.0), leaf_size_y_desc);
 
   rcl_interfaces::msg::ParameterDescriptor leaf_size_z_desc;
-  leaf_size_z_desc.name = "min_points_per_voxel";
+  leaf_size_z_desc.name = "leaf_size_z";
   leaf_size_z_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   leaf_size_z_desc.description = "The size of a leaf (on z) used for downsampling. \
     If negative, leaf_size is used instead.";
@@ -328,7 +328,6 @@ pcl_ros::Filter::add_common_params()
   }
   declare_parameter(
     min_points_per_voxel_desc.name, rclcpp::ParameterValue(2), min_points_per_voxel_desc);
-
 
   // filter: CropBox
 

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -259,8 +259,8 @@ pcl_ros::Filter::add_common_params()
   leaf_size_desc.name = "leaf_size";
   leaf_size_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   leaf_size_desc.description =
-    "Set the extent of a leaf, which is essentially the voxel size for accumulation.";
-  declare_parameter(leaf_size_desc.name, rclcpp::ParameterValue(0.05), leaf_size_desc);
+    "The size of a leaf (on x,y,z) used for downsampling";
+  declare_parameter(leaf_size_desc.name, rclcpp::ParameterValue(0.01), leaf_size_desc);
 
   rcl_interfaces::msg::ParameterDescriptor min_x_desc;
   min_x_desc.name = "min_x";
@@ -268,7 +268,7 @@ pcl_ros::Filter::add_common_params()
   min_x_desc.description =
     "Minimum x value below which points will be removed";
   declare_parameter(min_x_desc.name,
-    rclcpp::ParameterValue(std::numeric_limits<double>::min()), min_x_desc);
+    rclcpp::ParameterValue(-1.0), min_x_desc);
   
   rcl_interfaces::msg::ParameterDescriptor max_x_desc;
   max_x_desc.name = "max_x";
@@ -276,7 +276,7 @@ pcl_ros::Filter::add_common_params()
   max_x_desc.description =
     "Maximum x value above which points will be removed";
   declare_parameter(max_x_desc.name,
-    rclcpp::ParameterValue(std::numeric_limits<double>::max()), max_x_desc);
+    rclcpp::ParameterValue(1.0), max_x_desc);
 
   rcl_interfaces::msg::ParameterDescriptor min_y_desc;
   min_y_desc.name = "min_y";
@@ -284,7 +284,7 @@ pcl_ros::Filter::add_common_params()
   min_y_desc.description =
     "Minimum y value below which points will be removed";
   declare_parameter(min_y_desc.name,
-    rclcpp::ParameterValue(std::numeric_limits<double>::min()), min_y_desc);
+    rclcpp::ParameterValue(-1.0), min_y_desc);
   
   rcl_interfaces::msg::ParameterDescriptor max_y_desc;
   max_y_desc.name = "max_y";
@@ -292,7 +292,7 @@ pcl_ros::Filter::add_common_params()
   max_y_desc.description =
     "Maximum y value above which points will be removed";
   declare_parameter(max_y_desc.name,
-    rclcpp::ParameterValue(std::numeric_limits<double>::max()), max_y_desc);
+    rclcpp::ParameterValue(1.0), max_y_desc);
 
   rcl_interfaces::msg::ParameterDescriptor min_z_desc;
   min_z_desc.name = "min_z";
@@ -300,7 +300,7 @@ pcl_ros::Filter::add_common_params()
   min_z_desc.description =
     "Minimum z value below which points will be removed";
   declare_parameter(min_z_desc.name,
-    rclcpp::ParameterValue(std::numeric_limits<double>::min()), min_z_desc);
+    rclcpp::ParameterValue(-1.0), min_z_desc);
   
   rcl_interfaces::msg::ParameterDescriptor max_z_desc;
   max_z_desc.name = "max_z";
@@ -308,8 +308,22 @@ pcl_ros::Filter::add_common_params()
   max_z_desc.description =
     "Maximum z value above which points will be removed";
   declare_parameter(max_z_desc.name,
-    rclcpp::ParameterValue(std::numeric_limits<double>::max()), max_z_desc);
-    
+    rclcpp::ParameterValue(1.0), max_z_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor min_neighbors_desc;
+  min_neighbors_desc.name = "min_neighbors";
+  min_neighbors_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  min_neighbors_desc.description =
+    "The number of neighbors that need to be present in order to be classified as an inlier.";
+  declare_parameter(min_neighbors_desc.name, rclcpp::ParameterValue(5), min_neighbors_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor radius_search_desc;
+  radius_search_desc.name = "radius_search";
+  radius_search_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  radius_search_desc.description =
+    "Radius of the sphere that will determine which points are neighbors.";
+  declare_parameter(radius_search_desc.name, rclcpp::ParameterValue(0.1), radius_search_desc);
+
   return std::vector<std::string> {
     ffn_desc.name,
     flmin_desc.name,
@@ -323,6 +337,8 @@ pcl_ros::Filter::add_common_params()
     max_y_desc.name,
     min_z_desc.name,
     max_z_desc.name,
+    min_neighbors_desc.name,
+    radius_search_desc.name,
   };
 }
 

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -268,7 +268,67 @@ pcl_ros::Filter::add_common_params()
   leaf_size_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
   leaf_size_desc.description =
     "The size of a leaf (on x,y,z) used for downsampling";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = 0.0;
+    float_range.to_value = 1.0;
+    leaf_size_desc.floating_point_range.push_back(float_range);
+  }
   declare_parameter(leaf_size_desc.name, rclcpp::ParameterValue(0.01), leaf_size_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor leaf_size_x_desc;
+  leaf_size_x_desc.name = "leaf_size_x";
+  leaf_size_x_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  leaf_size_x_desc.description = "The size of a leaf (on x) used for downsampling. \
+    If negative, leaf_size is used instead.";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -1.0;
+    float_range.to_value = 1.0;
+    leaf_size_x_desc.floating_point_range.push_back(float_range);
+  }
+  declare_parameter(leaf_size_x_desc.name, rclcpp::ParameterValue(-1.0), leaf_size_x_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor leaf_size_y_desc;
+  leaf_size_y_desc.name = "leaf_size_y";
+  leaf_size_y_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  leaf_size_y_desc.description = "The size of a leaf (on y) used for downsampling. \
+    If negative, leaf_size is used instead.";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -1.0;
+    float_range.to_value = 1.0;
+    leaf_size_y_desc.floating_point_range.push_back(float_range);
+  }
+  declare_parameter(leaf_size_y_desc.name, rclcpp::ParameterValue(-1.0), leaf_size_y_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor leaf_size_z_desc;
+  leaf_size_z_desc.name = "min_points_per_voxel";
+  leaf_size_z_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  leaf_size_z_desc.description = "The size of a leaf (on z) used for downsampling. \
+    If negative, leaf_size is used instead.";
+  {
+    rcl_interfaces::msg::FloatingPointRange float_range;
+    float_range.from_value = -1.0;
+    float_range.to_value = 1.0;
+    leaf_size_z_desc.floating_point_range.push_back(float_range);
+  }
+  declare_parameter(leaf_size_z_desc.name, rclcpp::ParameterValue(-1.0), leaf_size_z_desc);
+
+  rcl_interfaces::msg::ParameterDescriptor min_points_per_voxel_desc;
+  min_points_per_voxel_desc.name = "min_points_per_voxel";
+  min_points_per_voxel_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  min_points_per_voxel_desc.description =
+    "The minimum number of points required for a voxel to be used.";
+  {
+    rcl_interfaces::msg::IntegerRange int_range;
+    int_range.from_value = 1;
+    int_range.to_value = 100000;
+    min_points_per_voxel_desc.integer_range.push_back(int_range);
+  }
+  declare_parameter(
+    min_points_per_voxel_desc.name, rclcpp::ParameterValue(2), min_points_per_voxel_desc);
+
 
   // filter: CropBox
 
@@ -407,6 +467,8 @@ pcl_ros::Filter::add_common_params()
   }
   declare_parameter(stddev_desc.name, rclcpp::ParameterValue(0.0), stddev_desc);
 
+  // filters: StatisticalOutlierRemoval, CropBox
+
   rcl_interfaces::msg::ParameterDescriptor negative_desc;
   negative_desc.name = "negative";
   negative_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
@@ -421,6 +483,10 @@ pcl_ros::Filter::add_common_params()
     flneg_desc.name,
     keep_organized_desc.name,
     leaf_size_desc.name,
+    leaf_size_x_desc.name,
+    leaf_size_y_desc.name,
+    leaf_size_z_desc.name,
+    min_points_per_voxel_desc.name,
     min_x_desc.name,
     max_x_desc.name,
     min_y_desc.name,

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -255,12 +255,20 @@ pcl_ros::Filter::add_common_params()
     "or removed from the PointCloud, thus potentially breaking its organized structure.";
   declare_parameter(keep_organized_desc.name, rclcpp::ParameterValue(false), keep_organized_desc);
 
+  rcl_interfaces::msg::ParameterDescriptor leaf_size_desc;
+  leaf_size_desc.name = "leaf_size";
+  leaf_size_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE;
+  leaf_size_desc.description =
+    "Set the extent of a leaf, which is essentially the voxel size for accumulation.";
+  declare_parameter(leaf_size_desc.name, rclcpp::ParameterValue(0.05), leaf_size_desc);
+
   return std::vector<std::string> {
     ffn_desc.name,
     flmin_desc.name,
     flmax_desc.name,
     flneg_desc.name,
-    keep_organized_desc.name
+    keep_organized_desc.name,
+    leaf_size_desc.name
   };
 }
 

--- a/pcl_ros/src/pcl_ros/filters/radius_outlier_removal.cpp
+++ b/pcl_ros/src/pcl_ros/filters/radius_outlier_removal.cpp
@@ -35,46 +35,53 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
 #include "pcl_ros/filters/radius_outlier_removal.hpp"
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl_ros::RadiusOutlierRemoval::child_init(ros::NodeHandle & nh, bool & has_service)
+pcl_ros::RadiusOutlierRemoval::RadiusOutlierRemoval(const rclcpp::NodeOptions & options)
+: Filter("RadiusOutlierRemovalNode", options)
 {
-  // Enable the dynamic reconfigure service
-  has_service = true;
-  srv_ = boost::make_shared<dynamic_reconfigure::Server<pcl_ros::RadiusOutlierRemovalConfig>>(nh);
-  dynamic_reconfigure::Server<pcl_ros::RadiusOutlierRemovalConfig>::CallbackType f = boost::bind(
-    &RadiusOutlierRemoval::config_callback, this, _1, _2);
-  srv_->setCallback(f);
+  use_frame_params();
+  std::vector<std::string> param_names = add_common_params();
 
-  return true;
+  callback_handle_ =
+    add_on_set_parameters_callback(
+    std::bind(
+      &RadiusOutlierRemoval::config_callback, this,
+      std::placeholders::_1));
+
+  config_callback(get_parameters(param_names));
+  // TODO(daisukes): lazy subscription after rclcpp#2060
+  subscribe();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-void
-pcl_ros::RadiusOutlierRemoval::config_callback(
-  pcl_ros::RadiusOutlierRemovalConfig & config,
-  uint32_t level)
+rcl_interfaces::msg::SetParametersResult
+pcl_ros::RadiusOutlierRemoval::config_callback(const std::vector<rclcpp::Parameter> & params)
 {
-  boost::mutex::scoped_lock lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
-  if (impl_.getMinNeighborsInRadius() != config.min_neighbors) {
-    impl_.setMinNeighborsInRadius(config.min_neighbors);
-    NODELET_DEBUG(
-      "[%s::config_callback] Setting the number of neighbors in radius: %d.",
-      getName().c_str(), config.min_neighbors);
+  for (const rclcpp::Parameter & param : params) {
+    if (param.get_name() == "min_neighbors") {
+      if (impl_.getMinNeighborsInRadius() != param.as_int()) {
+        RCLCPP_DEBUG(get_logger(), "Setting the number of neighbors in radius: %ld.",
+          param.as_int());
+        impl_.setMinNeighborsInRadius(param.as_int());
+      }
+    }
+    if (param.get_name() == "radius_search") {
+      if (impl_.getRadiusSearch() != param.as_double()) {
+        RCLCPP_DEBUG(get_logger(), "Setting the radius to search neighbors: %f.",
+          param.as_double());
+        impl_.setRadiusSearch(param.as_double());
+      }
+    }
   }
 
-  if (impl_.getRadiusSearch() != config.radius_search) {
-    impl_.setRadiusSearch(config.radius_search);
-    NODELET_DEBUG(
-      "[%s::config_callback] Setting the radius to search neighbors: %f.",
-      getName().c_str(), config.radius_search);
-  }
+  // TODO(sloretz) constraint validation
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  return result;
 }
 
-
-typedef pcl_ros::RadiusOutlierRemoval RadiusOutlierRemoval;
-PLUGINLIB_EXPORT_CLASS(RadiusOutlierRemoval, nodelet::Nodelet);
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(pcl_ros::RadiusOutlierRemoval)

--- a/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
+++ b/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
@@ -40,7 +40,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 pcl_ros::VoxelGrid::VoxelGrid(const rclcpp::NodeOptions & options)
-: Filter("VoxelGrid", options)
+: Filter("VoxelGridNode", options)
 {
   use_frame_params();
   std::vector<std::string> param_names = add_common_params();
@@ -103,6 +103,16 @@ pcl_ros::VoxelGrid::config_callback(const std::vector<rclcpp::Parameter> & param
         impl_.setFilterLimits(filter_min, filter_max);
       }
     }
+    if (param.get_name() == "filter_limit_negative") {
+      bool new_filter_limits_negative = param.as_bool();
+      if (impl_.getFilterLimitsNegative() != new_filter_limits_negative) {
+        RCLCPP_DEBUG(
+          get_logger(),
+          "Setting the filter negative flag to: %s.",
+          (new_filter_limits_negative ? "true" : "false"));
+        impl_.setFilterLimitsNegative(new_filter_limits_negative);
+      }
+    }
     if (param.get_name() == "leaf_size") {
       double new_leaf_size = param.as_double();
       if (leaf_size[0] != new_leaf_size) {
@@ -113,16 +123,6 @@ pcl_ros::VoxelGrid::config_callback(const std::vector<rclcpp::Parameter> & param
           new_leaf_size);
         // Set the filter min-max if different
         impl_.setLeafSize(leaf_size[0], leaf_size[1], leaf_size[2]);
-      }
-    }
-    if (param.get_name() == "filter_limit_negative") {
-      bool new_filter_limits_negative = param.as_bool();
-      if (impl_.getFilterLimitsNegative() != new_filter_limits_negative) {
-        RCLCPP_DEBUG(
-          get_logger(),
-          "Setting the filter negative flag to: %s.",
-          (new_filter_limits_negative ? "true" : "false"));
-        impl_.setFilterLimitsNegative(new_filter_limits_negative);
       }
     }
   }

--- a/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
+++ b/pcl_ros/src/pcl_ros/filters/voxel_grid.cpp
@@ -35,100 +35,102 @@
  *
  */
 
-#include <pluginlib/class_list_macros.h>
 #include "pcl_ros/filters/voxel_grid.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-bool
-pcl_ros::VoxelGrid::child_init(ros::NodeHandle & nh, bool & has_service)
-{
-  // Enable the dynamic reconfigure service
-  has_service = true;
-  srv_ = boost::make_shared<dynamic_reconfigure::Server<pcl_ros::VoxelGridConfig>>(nh);
-  dynamic_reconfigure::Server<pcl_ros::VoxelGridConfig>::CallbackType f = boost::bind(
-    &VoxelGrid::config_callback, this, _1, _2);
-  srv_->setCallback(f);
 
-  return true;
+pcl_ros::VoxelGrid::VoxelGrid(const rclcpp::NodeOptions & options)
+: Filter("VoxelGrid", options)
+{
+  use_frame_params();
+  std::vector<std::string> param_names = add_common_params();
+
+  callback_handle_ =
+    add_on_set_parameters_callback(
+    std::bind(
+      &VoxelGrid::config_callback, this,
+      std::placeholders::_1));
+
+  config_callback(get_parameters(param_names));
+  // TODO(daisukes): lazy subscription after rclcpp#2060
+  subscribe();
 }
 
-//////////////////////////////////////////////////////////////////////////////////////////////
-void
-pcl_ros::VoxelGrid::filter(
-  const PointCloud2::ConstPtr & input,
-  const IndicesPtr & indices,
-  PointCloud2 & output)
-{
-  boost::mutex::scoped_lock lock(mutex_);
-  pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
-  pcl_conversions::toPCL(*(input), *(pcl_input));
-  impl_.setInputCloud(pcl_input);
-  impl_.setIndices(indices);
-  pcl::PCLPointCloud2 pcl_output;
-  impl_.filter(pcl_output);
-  pcl_conversions::moveFromPCL(pcl_output, output);
-}
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-void
-pcl_ros::VoxelGrid::config_callback(pcl_ros::VoxelGridConfig & config, uint32_t level)
+rcl_interfaces::msg::SetParametersResult
+pcl_ros::VoxelGrid::config_callback(const std::vector<rclcpp::Parameter> & params)
 {
-  boost::mutex::scoped_lock lock(mutex_);
-
-  Eigen::Vector3f leaf_size = impl_.getLeafSize();
-
-  if (leaf_size[0] != config.leaf_size) {
-    leaf_size.setConstant(config.leaf_size);
-    NODELET_DEBUG("[config_callback] Setting the downsampling leaf size to: %f.", leaf_size[0]);
-    impl_.setLeafSize(leaf_size[0], leaf_size[1], leaf_size[2]);
-  }
+  std::lock_guard<std::mutex> lock(mutex_);
 
   double filter_min, filter_max;
   impl_.getFilterLimits(filter_min, filter_max);
-  if (filter_min != config.filter_limit_min) {
-    filter_min = config.filter_limit_min;
-    NODELET_DEBUG(
-      "[config_callback] Setting the minimum filtering value a point will be considered "
-      "from to: %f.",
-      filter_min);
-  }
-  if (filter_max != config.filter_limit_max) {
-    filter_max = config.filter_limit_max;
-    NODELET_DEBUG(
-      "[config_callback] Setting the maximum filtering value a point will be considered "
-      "from to: %f.",
-      filter_max);
-  }
-  impl_.setFilterLimits(filter_min, filter_max);
 
-  if (impl_.getFilterLimitsNegative() != config.filter_limit_negative) {
-    impl_.setFilterLimitsNegative(config.filter_limit_negative);
-    NODELET_DEBUG(
-      "[%s::config_callback] Setting the filter negative flag to: %s.",
-      getName().c_str(), config.filter_limit_negative ? "true" : "false");
-  }
+  Eigen::Vector3f leaf_size = impl_.getLeafSize();
 
-  if (impl_.getFilterFieldName() != config.filter_field_name) {
-    impl_.setFilterFieldName(config.filter_field_name);
-    NODELET_DEBUG(
-      "[config_callback] Setting the filter field name to: %s.",
-      config.filter_field_name.c_str());
+  for (const rclcpp::Parameter & param : params) {
+    if (param.get_name() == "filter_field_name") {
+      // Check the current value for the filter field
+      if (impl_.getFilterFieldName() != param.as_string()) {
+        // Set the filter field if different
+        impl_.setFilterFieldName(param.as_string());
+        RCLCPP_DEBUG(
+          get_logger(), "Setting the filter field name to: %s.",
+          param.as_string().c_str());
+      }
+    }
+    if (param.get_name() == "filter_limit_min") {
+      // Check the current values for filter min-max
+      if (filter_min != param.as_double()) {
+        filter_min = param.as_double();
+        RCLCPP_DEBUG(
+          get_logger(),
+          "Setting the minimum filtering value a point will be considered from to: %f.",
+          filter_min);
+        // Set the filter min-max if different
+        impl_.setFilterLimits(filter_min, filter_max);
+      }
+    }
+    if (param.get_name() == "filter_limit_max") {
+      // Check the current values for filter min-max
+      if (filter_max != param.as_double()) {
+        filter_max = param.as_double();
+        RCLCPP_DEBUG(
+          get_logger(),
+          "Setting the maximum filtering value a point will be considered from to: %f.",
+          filter_max);
+        // Set the filter min-max if different
+        impl_.setFilterLimits(filter_min, filter_max);
+      }
+    }
+    if (param.get_name() == "leaf_size") {
+      double new_leaf_size = param.as_double();
+      if (leaf_size[0] != new_leaf_size) {
+        leaf_size.setConstant(new_leaf_size);
+        RCLCPP_DEBUG(
+          get_logger(),
+          "Setting the downsampling leaf size to: %f.",
+          new_leaf_size);
+        // Set the filter min-max if different
+        impl_.setLeafSize(leaf_size[0], leaf_size[1], leaf_size[2]);
+      }
+    }
+    if (param.get_name() == "filter_limit_negative") {
+      bool new_filter_limits_negative = param.as_bool();
+      if (impl_.getFilterLimitsNegative() != new_filter_limits_negative) {
+        RCLCPP_DEBUG(
+          get_logger(),
+          "Setting the filter negative flag to: %s.",
+          (new_filter_limits_negative ? "true" : "false"));
+        impl_.setFilterLimitsNegative(new_filter_limits_negative);
+      }
+    }
   }
-
-  // ---[ These really shouldn't be here, and as soon as dynamic_reconfigure improves,
-  // we'll remove them and inherit from Filter
-  if (tf_input_frame_ != config.input_frame) {
-    tf_input_frame_ = config.input_frame;
-    NODELET_DEBUG("[config_callback] Setting the input TF frame to: %s.", tf_input_frame_.c_str());
-  }
-  if (tf_output_frame_ != config.output_frame) {
-    tf_output_frame_ = config.output_frame;
-    NODELET_DEBUG(
-      "[config_callback] Setting the output TF frame to: %s.",
-      tf_output_frame_.c_str());
-  }
-  // ]---
+  // TODO(sloretz) constraint validation
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  return result;
 }
 
-typedef pcl_ros::VoxelGrid VoxelGrid;
-PLUGINLIB_EXPORT_CLASS(VoxelGrid, nodelet::Nodelet);
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(pcl_ros::VoxelGrid)

--- a/pcl_ros/tests/filters/CMakeLists.txt
+++ b/pcl_ros/tests/filters/CMakeLists.txt
@@ -59,6 +59,12 @@ ament_add_pytest_test(test_pcl_ros::RadiusOutlierRemoval
       FILTER_PLUGIN=pcl_ros::RadiusOutlierRemoval
   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
 )
+ament_add_pytest_test(test_pcl_ros::StatisticalOutlierRemoval
+  test_filter_component.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_PLUGIN=pcl_ros::StatisticalOutlierRemoval
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
 
 # test executables
 ament_add_pytest_test(test_filter_extract_indices_node
@@ -96,5 +102,11 @@ ament_add_pytest_test(test_filter_radius_outlier_removal_node
   test_filter_executable.py
   ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
       FILTER_EXECUTABLE=filter_radius_outlier_removal_node
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
+ament_add_pytest_test(test_filter_statistical_outlier_removal_node
+  test_filter_executable.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_EXECUTABLE=filter_statistical_outlier_removal_node
   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
 )

--- a/pcl_ros/tests/filters/CMakeLists.txt
+++ b/pcl_ros/tests/filters/CMakeLists.txt
@@ -53,6 +53,12 @@ ament_add_pytest_test(test_pcl_ros::CropBox
       FILTER_PLUGIN=pcl_ros::CropBox
   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
 )
+ament_add_pytest_test(test_pcl_ros::RadiusOutlierRemoval
+  test_filter_component.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_PLUGIN=pcl_ros::RadiusOutlierRemoval
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
 
 # test executables
 ament_add_pytest_test(test_filter_extract_indices_node
@@ -84,5 +90,11 @@ ament_add_pytest_test(test_filter_crop_box_node
   test_filter_executable.py
   ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
       FILTER_EXECUTABLE=filter_crop_box_node
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
+ament_add_pytest_test(test_filter_radius_outlier_removal_node
+  test_filter_executable.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_EXECUTABLE=filter_radius_outlier_removal_node
   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
 )

--- a/pcl_ros/tests/filters/CMakeLists.txt
+++ b/pcl_ros/tests/filters/CMakeLists.txt
@@ -41,6 +41,18 @@ ament_add_pytest_test(test_pcl_ros::ProjectInliers
       PARAMETERS={'model_type':0}
   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
 )
+ament_add_pytest_test(test_pcl_ros::VoxelGrid
+  test_filter_component.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_PLUGIN=pcl_ros::VoxelGrid
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
+ament_add_pytest_test(test_pcl_ros::CropBox
+  test_filter_component.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_PLUGIN=pcl_ros::CropBox
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
 
 # test executables
 ament_add_pytest_test(test_filter_extract_indices_node
@@ -60,5 +72,17 @@ ament_add_pytest_test(test_filter_project_inliers_node
   ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
       FILTER_EXECUTABLE=filter_project_inliers_node
       PARAMETERS={'model_type':0}
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
+ament_add_pytest_test(test_filter_voxel_grid_node
+  test_filter_executable.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_EXECUTABLE=filter_voxel_grid_node
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
+ament_add_pytest_test(test_filter_crop_box_node
+  test_filter_executable.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_EXECUTABLE=filter_crop_box_node
   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
 )


### PR DESCRIPTION
# Overview
This PR migrates four PCL filters to the `ros2` branch of `pcl_ros` -- `VoxelGrid`, `CropBox`, `RadiusOutlierRemoval`, `StatisticalOutlierRemoval` . These were commented out in the code, but it seems like they mostly required conversion from `dynamic_reconfigure` to the new `rclcpp::Parameter` framework.