### PR TITLE
Migrate the ROS1 pcl::VoxelGrid filter to ROS2 pcl_ros::VoxelGrid

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -88,7 +88,7 @@ add_library(pcl_ros_filters SHARED
   src/pcl_ros/filters/project_inliers.cpp
   src/pcl_ros/filters/radius_outlier_removal.cpp
   src/pcl_ros/filters/statistical_outlier_removal.cpp
-#  src/pcl_ros/filters/voxel_grid.cpp
+  src/pcl_ros/filters/voxel_grid.cpp
   src/pcl_ros/filters/crop_box.cpp
 )
 target_link_libraries(pcl_ros_filters pcl_ros_tf ${PCL_LIBRARIES})
@@ -116,6 +116,10 @@ rclcpp_components_register_node(pcl_ros_filters
 rclcpp_components_register_node(pcl_ros_filters
   PLUGIN "pcl_ros::CropBox"
   EXECUTABLE filter_crop_box_node
+)
+rclcpp_components_register_node(pcl_ros_filters
+  PLUGIN "pcl_ros::VoxelGrid"
+  EXECUTABLE filter_voxel_grid_node
 )
 class_loader_hide_library_symbols(pcl_ros_filters)
 #

--- a/pcl_ros/include/pcl_ros/filters/voxel_grid.hpp
+++ b/pcl_ros/include/pcl_ros/filters/voxel_grid.hpp
@@ -40,10 +40,8 @@
 
 // PCL includes
 #include <pcl/filters/voxel_grid.h>
+#include <vector>
 #include "pcl_ros/filters/filter.hpp"
-
-// Dynamic reconfigure
-#include "pcl_ros/VoxelGridConfig.hpp"
 
 namespace pcl_ros
 {
@@ -53,38 +51,42 @@ namespace pcl_ros
 class VoxelGrid : public Filter
 {
 protected:
-  /** \brief Pointer to a dynamic reconfigure service. */
-  boost::shared_ptr<dynamic_reconfigure::Server<pcl_ros::VoxelGridConfig>> srv_;
-
-  /** \brief The PCL filter implementation used. */
-  pcl::VoxelGrid<pcl::PCLPointCloud2> impl_;
-
   /** \brief Call the actual filter.
     * \param input the input point cloud dataset
     * \param indices the input set of indices to use from \a input
     * \param output the resultant filtered dataset
     */
-  virtual void
+  inline void
   filter(
-    const PointCloud2::ConstPtr & input, const IndicesPtr & indices,
-    PointCloud2 & output);
+    const PointCloud2::ConstSharedPtr & input, const IndicesPtr & indices,
+    PointCloud2 & output) override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    pcl::PCLPointCloud2::Ptr pcl_input(new pcl::PCLPointCloud2);
+    pcl_conversions::toPCL(*(input), *(pcl_input));
+    impl_.setInputCloud(pcl_input);
+    impl_.setIndices(indices);
+    pcl::PCLPointCloud2 pcl_output;
+    impl_.filter(pcl_output);
+    pcl_conversions::moveFromPCL(pcl_output, output);
+  }
 
-  /** \brief Child initialization routine.
-    * \param nh ROS node handle
-    * \param has_service set to true if the child has a Dynamic Reconfigure service
+  /** \brief Parameter callback
+    * \param params parameter values to set
     */
-  bool
-  child_init(ros::NodeHandle & nh, bool & has_service);
+  rcl_interfaces::msg::SetParametersResult
+  config_callback(const std::vector<rclcpp::Parameter> & params);
 
-  /** \brief Dynamic reconfigure callback
-    * \param config the config object
-    * \param level the dynamic reconfigure level
-    */
-  void
-  config_callback(pcl_ros::VoxelGridConfig & config, uint32_t level);
+  OnSetParametersCallbackHandle::SharedPtr callback_handle_;
+
+private:
+  /** \brief The PCL filter implementation used. */
+  pcl::VoxelGrid<pcl::PCLPointCloud2> impl_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit VoxelGrid(const rclcpp::NodeOptions & options);
 };
 }  // namespace pcl_ros
 

--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -247,20 +247,11 @@ pcl_ros::Filter::add_common_params()
     "Set to true if we want to return the data outside [filter_limit_min; filter_limit_max].";
   declare_parameter(flneg_desc.name, rclcpp::ParameterValue(false), flneg_desc);
 
-  rcl_interfaces::msg::ParameterDescriptor keep_organized_desc;
-  keep_organized_desc.name = "keep_organized";
-  keep_organized_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
-  keep_organized_desc.description =
-    "Set whether the filtered points should be kept and set to NaN, "
-    "or removed from the PointCloud, thus potentially breaking its organized structure.";
-  declare_parameter(keep_organized_desc.name, rclcpp::ParameterValue(false), keep_organized_desc);
-
   return std::vector<std::string> {
     ffn_desc.name,
     flmin_desc.name,
     flmax_desc.name,
-    flneg_desc.name,
-    keep_organized_desc.name
+    flneg_desc.name
   };
 }
 

--- a/pcl_ros/src/pcl_ros/filters/passthrough.cpp
+++ b/pcl_ros/src/pcl_ros/filters/passthrough.cpp
@@ -41,7 +41,20 @@ pcl_ros::PassThrough::PassThrough(const rclcpp::NodeOptions & options)
 : Filter("PassThroughNode", options)
 {
   use_frame_params();
-  std::vector<std::string> param_names = add_common_params();
+  std::vector<std::string> common_param_names = add_common_params();
+
+  rcl_interfaces::msg::ParameterDescriptor keep_organized_desc;
+  keep_organized_desc.name = "keep_organized";
+  keep_organized_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  keep_organized_desc.description =
+    "Set whether the filtered points should be kept and set to NaN, "
+    "or removed from the PointCloud, thus potentially breaking its organized structure.";
+  declare_parameter(keep_organized_desc.name, rclcpp::ParameterValue(false), keep_organized_desc);
+
+  std::vector<std::string> param_names {
+    keep_organized_desc.name,
+  };
+  param_names.insert(param_names.end(), common_param_names.begin(), common_param_names.end());
 
   callback_handle_ =
     add_on_set_parameters_callback(
@@ -50,6 +63,7 @@ pcl_ros::PassThrough::PassThrough(const rclcpp::NodeOptions & options)
       std::placeholders::_1));
 
   config_callback(get_parameters(param_names));
+
   // TODO(daisukes): lazy subscription after rclcpp#2060
   subscribe();
 }

--- a/pcl_ros/tests/filters/CMakeLists.txt
+++ b/pcl_ros/tests/filters/CMakeLists.txt
@@ -59,6 +59,12 @@ ament_add_pytest_test(test_pcl_ros::CropBox
       FILTER_PLUGIN=pcl_ros::CropBox
   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
 )
+ament_add_pytest_test(test_pcl_ros::VoxelGrid
+  test_filter_component.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_PLUGIN=pcl_ros::VoxelGrid
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
 
 # test executables
 ament_add_pytest_test(test_filter_extract_indices_node
@@ -96,5 +102,11 @@ ament_add_pytest_test(test_filter_crop_box_node
   test_filter_executable.py
   ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
       FILTER_EXECUTABLE=filter_crop_box_node
+  APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
+)
+ament_add_pytest_test(test_filter_voxel_grid_node
+  test_filter_executable.py
+  ENV DUMMY_PLUGIN=pcl_ros_tests_filters::DummyTopics
+      FILTER_EXECUTABLE=filter_voxel_grid_node
   APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index
 )


### PR DESCRIPTION
## Overview

This PR migrates the VoxelGrid filter. The default parameter ranges and values were inherited from the hard-coded values in the ROS1 `.cfg` file for dynamic_reconfigure. Two things to note:

1. Note that I have changed the namespace from `pcl::` to `pcl_ros::` to be consistent with the other filters in the package. I don't expect this will be a breaking change because ROS1 packages will need to be hand-migrated to ROS2, and there's good benefit to having a consistent namespacing across the package.
2. I have removed the `keep_organized` parameter from common parameters in `filter.cpp` to the `Passthrough` where it is used, thereby allowing and the `VoxelGrid` and `Passthrough` to both use the common parameters. 

## Build

CI linter is surfacing `cpplint` and `uncrustify` errors from different files than those touched by this PR.