### PR TITLE
Fix Eigen3 uppercase in CMakeLists.txt

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -30,7 +30,7 @@ set(dependencies
   tf2
   tf2_geometry_msgs
   tf2_ros
-  EIGEN3
+  Eigen3
   PCL
 )
 


### PR DESCRIPTION
Eigen3 does not export a package configuration of the name EIGEN3 which leads to the following error when the generated cmake is used:
```
~/ws/install/pcl_ros/share/pcl_ros/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
  By not providing "FindEIGEN3.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "EIGEN3", but
  CMake did not find one.

  Could not find a package configuration file provided by "EIGEN3" with any
  of the following names:

    EIGEN3Config.cmake
    eigen3-config.cmake

  Add the installation prefix of "EIGEN3" to CMAKE_PREFIX_PATH or set
  "EIGEN3_DIR" to a directory containing one of the above files.  If "EIGEN3"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  ~/ws/install/pcl_ros/share/pcl_ros/cmake/pcl_rosConfig.cmake:41 (include)
  CMakeLists.txt:32 (find_package)
```