### PR TITLE
Fix build failures

### DIFF
--- a/pcl_conversions/package.xml
+++ b/pcl_conversions/package.xml
@@ -21,6 +21,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libpcl-all-dev</build_depend>
+
   <build_export_depend>libpcl-all-dev</build_export_depend>
 
   <depend>eigen</depend>

--- a/pcl_conversions/package.xml
+++ b/pcl_conversions/package.xml
@@ -21,7 +21,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>libpcl-all-dev</build_depend>
+  <build_export_depend>libpcl-all-dev</build_export_depend>
 
   <depend>eigen</depend>
   <depend>message_filters</depend>

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -27,6 +27,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libpcl-all-dev</build_depend>
+
   <build_export_depend>libpcl-all-dev</build_export_depend>
 
   <depend>eigen</depend>

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -27,7 +27,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>libpcl-all-dev</build_depend>
+  <build_export_depend>libpcl-all-dev</build_export_depend>
 
   <depend>eigen</depend>
   <depend>pcl_conversions</depend>


### PR DESCRIPTION
Adds changes to the `package.xml` files from #447 and some of #452 (there were merge conflicts which I don't have enough context to go through).

Hopefully this can fix buildfarm errors that require PCL to be exported, like
https://build.ros2.org/view/Hbin_uJ64/job/Hbin_uJ64__bosch_locator_bridge__ubuntu_jammy_amd64__binary/822/console

Once this is merged, another release needs to be done.