### PR TITLE
Fix pcd timestamp format output in pointcloud_to_pcd

### DIFF
--- a/pcl_ros/tools/pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/pointcloud_to_pcd.cpp
@@ -121,8 +121,9 @@ public:
     }
 
     std::stringstream ss;
-    ss << prefix_ << cloud_msg->header.stamp.sec << "." << cloud_msg->header.stamp.nanosec <<
-      ".pcd";
+    ss << prefix_ << cloud_msg->header.stamp.sec << "."
+      << std::setw(9) << std::setfill('0') << cloud_msg->header.stamp.nanosec
+      << ".pcd";
     RCLCPP_INFO(this->get_logger(), "Writing to %s", ss.str().c_str());
     if (rgb_) {
       pcl::PointCloud<pcl::PointXYZRGB> cloud;

--- a/pcl_ros/tools/pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/pointcloud_to_pcd.cpp
@@ -122,8 +122,8 @@ public:
 
     std::stringstream ss;
     ss << prefix_ << cloud_msg->header.stamp.sec << "."
-      << std::setw(9) << std::setfill('0') << cloud_msg->header.stamp.nanosec
-      << ".pcd";
+       << std::setw(9) << std::setfill('0') << cloud_msg->header.stamp.nanosec
+       << ".pcd";
     RCLCPP_INFO(this->get_logger(), "Writing to %s", ss.str().c_str());
     if (rgb_) {
       pcl::PointCloud<pcl::PointXYZRGB> cloud;


### PR DESCRIPTION
Fix pcd timestamp indentation offset if nanosec value is less than 100000000 ns