### PR TITLE
Enable PCL conversions for PCL 1.15

### DIFF
--- a/pcl_conversions/include/pcl_conversions/pcl_conversions.h
+++ b/pcl_conversions/include/pcl_conversions/pcl_conversions.h
@@ -305,28 +305,38 @@ namespace pcl_conversions {
   void fromPCL(const pcl::PointIndices &pcl_pi, pcl_msgs::msg::PointIndices &pi)
   {
     fromPCL(pcl_pi.header, pi.header);
-    pi.indices = pcl_pi.indices;
+    pi.indices.clear();
+    pi.indices.insert(pi.indices.begin(), pcl_pi.indices.begin(), pcl_pi.indices.end());
   }
 
   inline
   void moveFromPCL(pcl::PointIndices &pcl_pi, pcl_msgs::msg::PointIndices &pi)
   {
     fromPCL(pcl_pi.header, pi.header);
-    pi.indices.swap(pcl_pi.indices);
+    pi.indices.clear();
+    pi.indices.insert(pi.indices.begin(),
+                      std::make_move_iterator(pcl_pi.indices.begin()),
+                      std::make_move_iterator(pcl_pi.indices.end()));
+    pcl_pi.indices.clear();
   }
 
   inline
   void toPCL(const pcl_msgs::msg::PointIndices &pi, pcl::PointIndices &pcl_pi)
   {
     toPCL(pi.header, pcl_pi.header);
-    pcl_pi.indices = pi.indices;
+    pcl_pi.indices.clear();
+    pcl_pi.indices.insert(pcl_pi.indices.begin(), pi.indices.begin(), pi.indices.end());
   }
 
   inline
   void moveToPCL(pcl_msgs::msg::PointIndices &pi, pcl::PointIndices &pcl_pi)
   {
     toPCL(pi.header, pcl_pi.header);
-    pcl_pi.indices.swap(pi.indices);
+    pcl_pi.indices.clear();
+    pcl_pi.indices.insert(pcl_pi.indices.begin(),
+                          std::make_move_iterator(pi.indices.begin()),
+                          std::make_move_iterator(pi.indices.end()));
+    pi.indices.clear();
   }
 
   /** pcl::ModelCoefficients <=> pcl_msgs::ModelCoefficients **/


### PR DESCRIPTION
Newer PCL seems to have changed indices signedness. This patch makes conversions work for  1.15. See https://github.com/PointCloudLibrary/pcl/blob/master/CHANGES.md

This will fix errors like:
```
In file included from third_party/ros2_pcl_conversions/tests/ros2_pcl_conversions_test.cpp:2:
external/ros2_pcl_conversions/pcl_conversions/include/pcl_conversions/pcl_conversions.h:308:16: error: no viable overloaded '='
  308 |     pi.indices = pcl_pi.indices;
      |     ~~~~~~~~~~ ^ ~~~~~~~~~~~~~~
external/ubuntu_jammy_amd64_sysroot/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:695:7: note: candidate function not viable: no known conversion from 'const vector<index_t, allocator<unsigned int>>' to 'const vector<int, allocator<int>>' for 1st argument
  695 |       operator=(const vector& __x);
      |       ^         ~~~~~~~~~~~~~~~~~
external/ubuntu_jammy_amd64_sysroot/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:709:7: note: candidate function not viable: no known conversion from 'const vector<index_t, allocator<unsigned int>>' to 'vector<int, allocator<int>>' for 1st argument
  709 |       operator=(vector&& __x) noexcept(_Alloc_traits::_S_nothrow_move())
      |       ^         ~~~~~~~~~~~~
external/ubuntu_jammy_amd64_sysroot/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:730:7: note: candidate function not viable: no known conversion from 'const Indices' (aka 'const vector<unsigned int, std::allocator<unsigned int>>') to 'initializer_list<value_type>' (aka 'initializer_list<int>') for 1st argument
  730 |       operator=(initializer_list<value_type> __l)
      |       ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from third_party/ros2_pcl_conversions/tests/ros2_pcl_conversions_test.cpp:2:
external/ros2_pcl_conversions/pcl_conversions/include/pcl_conversions/pcl_conversions.h:315:21: error: non-const lvalue reference to type 'vector<int, allocator<int>>' cannot bind to a value of unrelated type 'vector<index_t, allocator<unsigned int>>'
  315 |     pi.indices.swap(pcl_pi.indices);
      |                     ^~~~~~~~~~~~~~
external/ubuntu_jammy_amd64_sysroot/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:1480:20: note: passing argument to parameter '__x' here
 1480 |       swap(vector& __x) _GLIBCXX_NOEXCEPT
      |                    ^
In file included from third_party/ros2_pcl_conversions/tests/ros2_pcl_conversions_test.cpp:2:
external/ros2_pcl_conversions/pcl_conversions/include/pcl_conversions/pcl_conversions.h:322:20: error: no viable overloaded '='
  322 |     pcl_pi.indices = pi.indices;
      |     ~~~~~~~~~~~~~~ ^ ~~~~~~~~~~
external/ubuntu_jammy_amd64_sysroot/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:695:7: note: candidate function not viable: no known conversion from 'const vector<int32_t, allocator<int>>' to 'const vector<unsigned int, allocator<unsigned int>>' for 1st argument
  695 |       operator=(const vector& __x);
      |       ^         ~~~~~~~~~~~~~~~~~
external/ubuntu_jammy_amd64_sysroot/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:709:7: note: candidate function not viable: no known conversion from 'const vector<int32_t, allocator<int>>' to 'vector<unsigned int, allocator<unsigned int>>' for 1st argument
  709 |       operator=(vector&& __x) noexcept(_Alloc_traits::_S_nothrow_move())
      |       ^         ~~~~~~~~~~~~
external/ubuntu_jammy_amd64_sysroot/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:730:7: note: candidate function not viable: no known conversion from 'const _indices_type' (aka 'const vector<int, allocator<int>>') to 'initializer_list<value_type>' (aka 'initializer_list<unsigned int>') for 1st argument
  730 |       operator=(initializer_list<value_type> __l)
      |       ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from third_party/ros2_pcl_conversions/tests/ros2_pcl_conversions_test.cpp:2:
external/ros2_pcl_conversions/pcl_conversions/include/pcl_conversions/pcl_conversions.h:329:25: error: non-const lvalue reference to type 'vector<unsigned int, allocator<unsigned int>>' cannot bind to a value of unrelated type 'vector<int32_t, allocator<int>>'
  329 |     pcl_pi.indices.swap(pi.indices);
      |                         ^~~~~~~~~~
external/ubuntu_jammy_amd64_sysroot/usr/lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:1480:20: note: passing argument to parameter '__x' here
 1480 |       swap(vector& __x) _GLIBCXX_NOEXCEPT
      |                    ^
4 errors generated.
```