### PR TITLE
Added crop box marker publisher

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(visualization_msgs REQUIRED)
 
 set(dependencies
   pcl_conversions
@@ -36,6 +37,7 @@ set(dependencies
   tf2_ros
   EIGEN3
   PCL
+  visualization_msgs
 )
 
 ## Declare the pcl_ros_tf library

--- a/pcl_ros/include/pcl_ros/filters/crop_box.hpp
+++ b/pcl_ros/include/pcl_ros/filters/crop_box.hpp
@@ -42,6 +42,7 @@
 // PCL includes
 #include <pcl/filters/crop_box.h>
 #include <vector>
+#include <visualization_msgs/msg/marker.hpp>
 #include "pcl_ros/filters/filter.hpp"
 
 namespace pcl_ros
@@ -70,8 +71,21 @@ protected:
     */
   rcl_interfaces::msg::SetParametersResult
   config_callback(const std::vector<rclcpp::Parameter> & params);
+  /** \brief Create publishers for output PointCloud2 data as well as the crop box marker. */
+  void createPublishers() override;
+  /** \brief Update the crop box marker msg. */
+  void update_marker_msg();
 
   OnSetParametersCallbackHandle::SharedPtr callback_handle_;
+  /** \brief The crop box marker msg publisher for visualization and debugging purposes. */
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr crop_box_marker_publisher_;
+  /**
+   * \brief The crop box marker message.
+   *
+   * The marker's cube gets updated whenever the min/max points are changed.
+   * The header is adjusted with every point cloud callback.
+   */
+  visualization_msgs::msg::Marker crop_box_marker_msg_;
 
 private:
   /** \brief The PCL filter implementation used. */

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -41,6 +41,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
+  <depend>visualization_msgs</depend>
 
   <exec_depend>libpcl-common</exec_depend>
   <exec_depend>libpcl-features</exec_depend>

--- a/pcl_ros/src/pcl_ros/filters/crop_box.cpp
+++ b/pcl_ros/src/pcl_ros/filters/crop_box.cpp
@@ -172,6 +172,13 @@ pcl_ros::CropBox::filter(
   pcl::PCLPointCloud2 pcl_output;
   impl_.filter(pcl_output);
   pcl_conversions::moveFromPCL(pcl_output, output);
+  // Publish the crop box as a cube marker for visualization purposes
+  if (crop_box_marker_publisher_->get_subscription_count() > 0) {
+    crop_box_marker_msg_.header.frame_id =
+      tf_input_frame_.empty() ? input->header.frame_id : tf_input_frame_;
+    crop_box_marker_msg_.header.stamp = input->header.stamp;
+    crop_box_marker_publisher_->publish(crop_box_marker_msg_);
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -226,12 +233,14 @@ pcl_ros::CropBox::config_callback(const std::vector<rclcpp::Parameter> & params)
     }
   }
 
+  auto crop_box_marker_updated = false;
   // Check the current values for minimum point
   if (min_point != impl_.getMin()) {
     RCLCPP_DEBUG(
       get_logger(), "Setting the minimum point to: %f %f %f.",
       min_point(0), min_point(1), min_point(2));
     impl_.setMin(min_point);
+    crop_box_marker_updated = true;
   }
 
   // Check the current values for the maximum point
@@ -240,12 +249,44 @@ pcl_ros::CropBox::config_callback(const std::vector<rclcpp::Parameter> & params)
       get_logger(), "Setting the maximum point to: %f %f %f.",
       max_point(0), max_point(1), max_point(2));
     impl_.setMax(max_point);
+    crop_box_marker_updated = true;
+  }
+  if (crop_box_marker_updated) {
+    update_marker_msg();
   }
 
   // Range constraints are enforced by rclcpp::Parameter.
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
   return result;
+}
+
+void pcl_ros::CropBox::createPublishers()
+{
+  pcl_ros::Filter::createPublishers();
+  crop_box_marker_publisher_ = create_publisher<visualization_msgs::msg::Marker>(
+    "~/crop_box_marker", max_queue_size_);
+}
+
+void pcl_ros::CropBox::update_marker_msg()
+{
+  auto min_point = impl_.getMin();
+  auto max_point = impl_.getMax();
+  crop_box_marker_msg_.ns = get_name() + std::string("/crop_box_marker");
+  crop_box_marker_msg_.type = visualization_msgs::msg::Marker::CUBE;
+  crop_box_marker_msg_.action = visualization_msgs::msg::Marker::ADD;
+  crop_box_marker_msg_.color.g = 1.0;
+  crop_box_marker_msg_.color.a = 0.5;
+  crop_box_marker_msg_.frame_locked = true;
+  Eigen::Vector4f center = (max_point + min_point) / 2.0;
+  Eigen::Vector4f size = max_point - min_point;
+  crop_box_marker_msg_.pose.position.x = center.x();
+  crop_box_marker_msg_.pose.position.y = center.y();
+  crop_box_marker_msg_.pose.position.z = center.z();
+  crop_box_marker_msg_.pose.orientation.w = 1.0;
+  crop_box_marker_msg_.scale.x = size.x();
+  crop_box_marker_msg_.scale.y = size.y();
+  crop_box_marker_msg_.scale.z = size.z();
 }
 
 #include "rclcpp_components/register_node_macro.hpp"


### PR DESCRIPTION
Hi,

I always found it a bit frustrating not being able to visualize the crop box specially when things don't go as expected and I would need to debug what is going wrong.

I thought it would be nice to have a marker msg which correctly (taking into account the crop box frame) visualizes the crop box filter. 

![Screenshot from 2025-04-29 16-57-00](https://github.com/user-attachments/assets/0cd717cc-c53b-462d-8d30-f82b8dc8c991)
![Screenshot from 2025-04-29 16-56-48](https://github.com/user-attachments/assets/830930c1-6b7f-43eb-9e33-d53dea3c0aec)


The publishing logic could  be a discussion point. I thought that it would be best to prepare the box characteristics upon parameter changes and publish it with the pointcloud cb. I also tried alternative approaches such as publishing a transient local message with parameter updates but that did not seem so practical because of the following reasons:

- Not necessarily, input_frame is set.
- The incoming messages can have different header frames, hence the marker should always use the latest one.
- Pointclouds can come after the initial parameter configuration, hence you would need to implement flags to retrigger marker publishing.
- etc.