### PR TITLE
fix deprecation of .h files in message_filters

### DIFF
--- a/pcl_ros/include/pcl_ros/features/feature.hpp
+++ b/pcl_ros/include/pcl_ros/features/feature.hpp
@@ -42,7 +42,7 @@
 #include <pcl/features/feature.h>
 #include <pcl_msgs/PointIndices.h>
 
-#include <message_filters/pass_through.h>
+#include <message_filters/pass_through.hpp>
 
 // Dynamic reconfigure
 #include <dynamic_reconfigure/server.h>
@@ -117,7 +117,7 @@ protected:
   bool use_surface_;
 
   /** \brief Parameter for the spatial locator tree. By convention, the values represent:
-    * 0: ANN (Approximate Nearest Neigbor library) kd-tree
+    * 0: ANN (Approximate Nearest Neighbor library) kd-tree
     * 1: FLANN (Fast Library for Approximate Nearest Neighbors) kd-tree
     * 2: Organized spatial dataset index
     */

--- a/pcl_ros/include/pcl_ros/features/feature.hpp
+++ b/pcl_ros/include/pcl_ros/features/feature.hpp
@@ -42,7 +42,6 @@
 #include <pcl/features/feature.h>
 #include <pcl_msgs/PointIndices.h>
 
-#include <message_filters/pass_through.hpp>
 
 // Dynamic reconfigure
 #include <dynamic_reconfigure/server.h>
@@ -50,6 +49,7 @@
 // PCL conversions
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <message_filters/pass_through.hpp>
 #include "pcl_ros/pcl_nodelet.hpp"
 #include "pcl_ros/FeatureConfig.hpp"
 

--- a/pcl_ros/include/pcl_ros/filters/project_inliers.hpp
+++ b/pcl_ros/include/pcl_ros/filters/project_inliers.hpp
@@ -40,7 +40,7 @@
 
 // PCL includes
 #include <pcl/filters/project_inliers.h>
-#include <message_filters/subscriber.h>
+#include <message_filters/subscriber.hpp>
 #include <memory>
 #include "pcl_ros/filters/filter.hpp"
 

--- a/pcl_ros/include/pcl_ros/filters/project_inliers.hpp
+++ b/pcl_ros/include/pcl_ros/filters/project_inliers.hpp
@@ -40,9 +40,9 @@
 
 // PCL includes
 #include <pcl/filters/project_inliers.h>
-#include <message_filters/subscriber.hpp>
 #include <memory>
 #include "pcl_ros/filters/filter.hpp"
+#include <message_filters/subscriber.hpp>
 
 
 namespace pcl_ros

--- a/pcl_ros/include/pcl_ros/io/concatenate_data.hpp
+++ b/pcl_ros/include/pcl_ros/io/concatenate_data.hpp
@@ -41,11 +41,11 @@
 // ROS includes
 #include <tf/transform_listener.h>
 #include <nodelet_topic_tools/nodelet_lazy.h>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/pass_through.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/synchronizer.hpp>
+#include <message_filters/pass_through.hpp>
+#include <message_filters/sync_policies/exact_time.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
 #include <string>
 #include <vector>
 

--- a/pcl_ros/include/pcl_ros/io/concatenate_data.hpp
+++ b/pcl_ros/include/pcl_ros/io/concatenate_data.hpp
@@ -41,13 +41,13 @@
 // ROS includes
 #include <tf/transform_listener.h>
 #include <nodelet_topic_tools/nodelet_lazy.h>
+#include <string>
+#include <vector>
 #include <message_filters/subscriber.hpp>
 #include <message_filters/synchronizer.hpp>
 #include <message_filters/pass_through.hpp>
 #include <message_filters/sync_policies/exact_time.hpp>
 #include <message_filters/sync_policies/approximate_time.hpp>
-#include <string>
-#include <vector>
 
 namespace pcl_ros
 {

--- a/pcl_ros/include/pcl_ros/io/concatenate_fields.hpp
+++ b/pcl_ros/include/pcl_ros/io/concatenate_fields.hpp
@@ -40,10 +40,10 @@
 
 // ROS includes
 #include <nodelet_topic_tools/nodelet_lazy.h>
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/synchronizer.hpp>
+#include <message_filters/sync_policies/exact_time.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
 
 #include <sensor_msgs/PointCloud2.h>
 

--- a/pcl_ros/include/pcl_ros/io/concatenate_fields.hpp
+++ b/pcl_ros/include/pcl_ros/io/concatenate_fields.hpp
@@ -40,15 +40,16 @@
 
 // ROS includes
 #include <nodelet_topic_tools/nodelet_lazy.h>
-#include <message_filters/subscriber.hpp>
-#include <message_filters/synchronizer.hpp>
-#include <message_filters/sync_policies/exact_time.hpp>
-#include <message_filters/sync_policies/approximate_time.hpp>
 
 #include <sensor_msgs/PointCloud2.h>
 
 #include <map>
 #include <vector>
+
+#include <message_filters/subscriber.hpp>
+#include <message_filters/synchronizer.hpp>
+#include <message_filters/sync_policies/exact_time.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
 
 namespace pcl_ros
 {

--- a/pcl_ros/include/pcl_ros/pcl_node.hpp
+++ b/pcl_ros/include/pcl_ros/pcl_node.hpp
@@ -44,10 +44,6 @@
 #ifndef PCL_ROS__PCL_NODE_HPP_
 #define PCL_ROS__PCL_NODE_HPP_
 
-#include <message_filters/subscriber.hpp>
-#include <message_filters/synchronizer.hpp>
-#include <message_filters/sync_policies/exact_time.hpp>
-#include <message_filters/sync_policies/approximate_time.hpp>
 #include <pcl/pcl_base.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
@@ -58,6 +54,10 @@
 #include <string>
 #include <vector>
 
+#include <message_filters/subscriber.hpp>
+#include <message_filters/synchronizer.hpp>
+#include <message_filters/sync_policies/exact_time.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <pcl_msgs/msg/point_indices.hpp>

--- a/pcl_ros/include/pcl_ros/pcl_node.hpp
+++ b/pcl_ros/include/pcl_ros/pcl_node.hpp
@@ -44,10 +44,10 @@
 #ifndef PCL_ROS__PCL_NODE_HPP_
 #define PCL_ROS__PCL_NODE_HPP_
 
-#include <message_filters/subscriber.h>
-#include <message_filters/synchronizer.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/subscriber.hpp>
+#include <message_filters/synchronizer.hpp>
+#include <message_filters/sync_policies/exact_time.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
 #include <pcl/pcl_base.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
@@ -135,7 +135,7 @@ public:
       desc.name = "approximate_sync";
       desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
       desc.description =
-        "Match indices and point cloud messages if time stamps are approximatly the same.";
+        "Match indices and point cloud messages if time stamps are approximately the same.";
       desc.read_only = true;
       approximate_sync_ = declare_parameter(desc.name, approximate_sync_, desc);
     }

--- a/pcl_ros/include/pcl_ros/segmentation/extract_polygonal_prism_data.hpp
+++ b/pcl_ros/include/pcl_ros/segmentation/extract_polygonal_prism_data.hpp
@@ -38,11 +38,11 @@
 #ifndef PCL_ROS__SEGMENTATION__EXTRACT_POLYGONAL_PRISM_DATA_HPP_
 #define PCL_ROS__SEGMENTATION__EXTRACT_POLYGONAL_PRISM_DATA_HPP_
 
+#include <pcl/segmentation/extract_polygonal_prism_data.h>
+#include <dynamic_reconfigure/server.h>
 #include <message_filters/sync_policies/exact_time.hpp>
 #include <message_filters/sync_policies/approximate_time.hpp>
 #include <message_filters/pass_through.hpp>
-#include <pcl/segmentation/extract_polygonal_prism_data.h>
-#include <dynamic_reconfigure/server.h>
 #include "pcl_ros/ExtractPolygonalPrismDataConfig.hpp"
 #include "pcl_ros/pcl_nodelet.hpp"
 

--- a/pcl_ros/include/pcl_ros/segmentation/extract_polygonal_prism_data.hpp
+++ b/pcl_ros/include/pcl_ros/segmentation/extract_polygonal_prism_data.hpp
@@ -38,9 +38,9 @@
 #ifndef PCL_ROS__SEGMENTATION__EXTRACT_POLYGONAL_PRISM_DATA_HPP_
 #define PCL_ROS__SEGMENTATION__EXTRACT_POLYGONAL_PRISM_DATA_HPP_
 
-#include <message_filters/sync_policies/exact_time.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/pass_through.h>
+#include <message_filters/sync_policies/exact_time.hpp>
+#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/pass_through.hpp>
 #include <pcl/segmentation/extract_polygonal_prism_data.h>
 #include <dynamic_reconfigure/server.h>
 #include "pcl_ros/ExtractPolygonalPrismDataConfig.hpp"

--- a/pcl_ros/include/pcl_ros/segmentation/sac_segmentation.hpp
+++ b/pcl_ros/include/pcl_ros/segmentation/sac_segmentation.hpp
@@ -38,10 +38,10 @@
 #ifndef PCL_ROS__SEGMENTATION__SAC_SEGMENTATION_HPP_
 #define PCL_ROS__SEGMENTATION__SAC_SEGMENTATION_HPP_
 
-#include <message_filters/pass_through.hpp>
 #include <pcl/segmentation/sac_segmentation.h>
 #include <dynamic_reconfigure/server.h>
 #include <string>
+#include <message_filters/pass_through.hpp>
 #include "pcl_ros/pcl_nodelet.hpp"
 #include "pcl_ros/SACSegmentationConfig.hpp"
 #include "pcl_ros/SACSegmentationFromNormalsConfig.hpp"

--- a/pcl_ros/include/pcl_ros/segmentation/sac_segmentation.hpp
+++ b/pcl_ros/include/pcl_ros/segmentation/sac_segmentation.hpp
@@ -38,7 +38,7 @@
 #ifndef PCL_ROS__SEGMENTATION__SAC_SEGMENTATION_HPP_
 #define PCL_ROS__SEGMENTATION__SAC_SEGMENTATION_HPP_
 
-#include <message_filters/pass_through.h>
+#include <message_filters/pass_through.hpp>
 #include <pcl/segmentation/sac_segmentation.h>
 #include <dynamic_reconfigure/server.h>
 #include <string>

--- a/pcl_ros/src/pcl_ros/features/feature.cpp
+++ b/pcl_ros/src/pcl_ros/features/feature.cpp
@@ -48,7 +48,7 @@
 // #include "principal_curvatures.cpp"
 // #include "vfh.cpp"
 #include <pcl/common/io.h>
-#include <message_filters/null_types.h>
+#include <message_filters/null_types.hpp>
 #include <vector>
 #include "pcl_ros/features/feature.hpp"
 

--- a/pcl_ros/src/pcl_ros/features/feature.cpp
+++ b/pcl_ros/src/pcl_ros/features/feature.cpp
@@ -48,8 +48,8 @@
 // #include "principal_curvatures.cpp"
 // #include "vfh.cpp"
 #include <pcl/common/io.h>
-#include <message_filters/null_types.hpp>
 #include <vector>
+#include <message_filters/null_types.hpp>
 #include "pcl_ros/features/feature.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/filters/features/feature.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/feature.cpp
@@ -48,7 +48,7 @@
 // #include "principal_curvatures.cpp"
 // #include "vfh.cpp"
 #include <pcl/common/io.h>
-#include <message_filters/null_types.h>
+#include <message_filters/null_types.hpp>
 #include <vector>
 #include "pcl_ros/features/feature.hpp"
 

--- a/pcl_ros/src/pcl_ros/filters/features/feature.cpp
+++ b/pcl_ros/src/pcl_ros/filters/features/feature.cpp
@@ -48,8 +48,8 @@
 // #include "principal_curvatures.cpp"
 // #include "vfh.cpp"
 #include <pcl/common/io.h>
-#include <message_filters/null_types.hpp>
 #include <vector>
+#include <message_filters/null_types.hpp>
 #include "pcl_ros/features/feature.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////////////////

--- a/pcl_ros/src/pcl_ros/io/io.cpp
+++ b/pcl_ros/src/pcl_ros/io/io.cpp
@@ -37,7 +37,7 @@
 
 #include <pluginlib/class_list_macros.h>
 #include <sensor_msgs/PointCloud2.h>
-#include <message_filters/subscriber.h>
+#include <message_filters/subscriber.hpp>
 // #include <pcl_ros/subscriber.hpp>
 #include <nodelet_topic_tools/nodelet_mux.h>
 #include <nodelet_topic_tools/nodelet_demux.h>

--- a/pcl_ros/src/pcl_ros/io/io.cpp
+++ b/pcl_ros/src/pcl_ros/io/io.cpp
@@ -37,10 +37,10 @@
 
 #include <pluginlib/class_list_macros.h>
 #include <sensor_msgs/PointCloud2.h>
-#include <message_filters/subscriber.hpp>
-// #include <pcl_ros/subscriber.hpp>
 #include <nodelet_topic_tools/nodelet_mux.h>
 #include <nodelet_topic_tools/nodelet_demux.h>
+
+#include <message_filters/subscriber.hpp>
 
 typedef nodelet::NodeletMUX<sensor_msgs::PointCloud2,
     message_filters::Subscriber<sensor_msgs::PointCloud2>> NodeletMUX;


### PR DESCRIPTION
Fixes:

```
/opt/ros/rolling/include/message_filters/message_filters/synchronizer.h:18:2: warning: #warning This header is obsolete, please include message_filters/synchronizer.hpp instead [-Wcpp]
   18 | #warning This header is obsolete, please include message_filters/synchronizer.hpp instead
      |  ^~~~~~~
```
