### PR TITLE
Fix downstream CMake error: rosbag2_transport not found

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -216,16 +216,17 @@ ament_target_dependencies(combined_pointcloud_to_pcd_lib
   tf2_ros)
 
 add_library(bag_to_pcd_lib SHARED tools/bag_to_pcd.cpp)
-target_link_libraries(bag_to_pcd_lib
-  ${PCL_LIBRARIES})
-target_include_directories(bag_to_pcd_lib PUBLIC
-  ${PCL_INCLUDE_DIRS})
-ament_target_dependencies(bag_to_pcd_lib
-  rclcpp
-  rclcpp_components
-  sensor_msgs
-  pcl_conversions
-  rosbag2_transport)
+target_include_directories(bag_to_pcd_lib PRIVATE
+  ${PCL_INCLUDE_DIRS}
+)
+target_link_libraries(bag_to_pcd_lib PRIVATE
+  ${PCL_LIBRARIES}
+  ${sensor_msgs_TARGETS}
+  pcl_conversions::pcl_conversions
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rosbag2_transport::rosbag2_transport
+)
 rclcpp_components_register_node(bag_to_pcd_lib
   PLUGIN "pcl_ros::BagToPCD"
   EXECUTABLE bag_to_pcd)


### PR DESCRIPTION
`bag_to_pcd_lib` was linked publicly to `rosbag2_transport`, which caused downstream packages to also try linking against it. However, `rosbag2_transport` is an internal dependency, and we don't want to expose it to downstream packages.

Since `bag_to_pcd_lib` is a tool with no public headers, it doesn't need to expose this dependency. Switching to private linking resolves the issue and keeps the dependency internal.

For example, try compiling this packages: https://github.com/pradyum/dual_laser_merger

@vladimirjendrol