### PR TITLE
Bump minimum cmake version to 3.20

### DIFF
--- a/pcl_conversions/CMakeLists.txt
+++ b/pcl_conversions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(pcl_conversions)
 
 # Default to C++14

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(pcl_ros)
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/perception_pcl/CMakeLists.txt
+++ b/perception_pcl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(perception_pcl)
 find_package(ament_cmake REQUIRED)
 ament_package()


### PR DESCRIPTION
This gets rid of the warning that compatibility with CMake < 3.10 will be removed from a future version of CMake. The version 3.20 is the one used in rclcpp for jazzy and higher.