### PR TITLE
Fix warning: 'subscribe<>' is deprecated: use rclcpp::QoS

### DIFF
--- a/pcl_ros/src/pcl_ros/filters/filter.cpp
+++ b/pcl_ros/src/pcl_ros/filters/filter.cpp
@@ -123,8 +123,7 @@ pcl_ros::Filter::subscribe()
   // If we're supposed to look for PointIndices (indices)
   if (use_indices_) {
     // Subscribe to the input using a filter
-    auto sensor_qos_profile =
-      rclcpp::SensorDataQoS().keep_last(max_queue_size_).get_rmw_qos_profile();
+    auto sensor_qos_profile = rclcpp::SensorDataQoS().keep_last(max_queue_size_);
     sub_input_filter_.subscribe(this, "input", sensor_qos_profile);
     sub_indices_filter_.subscribe(this, "indices", sensor_qos_profile);
 

--- a/pcl_ros/src/pcl_ros/filters/project_inliers.cpp
+++ b/pcl_ros/src/pcl_ros/filters/project_inliers.cpp
@@ -105,12 +105,9 @@ pcl_ros::ProjectInliers::subscribe()
   if (use_indices_)
   {*/
 
-  auto qos_profile = rclcpp::QoS(
-    rclcpp::KeepLast(max_queue_size_),
-    rmw_qos_profile_default).get_rmw_qos_profile();
-  auto sensor_qos_profile = rclcpp::QoS(
-    rclcpp::KeepLast(max_queue_size_),
-    rmw_qos_profile_sensor_data).get_rmw_qos_profile();
+  auto qos_profile = rclcpp::QoS(rclcpp::KeepLast(max_queue_size_), rmw_qos_profile_default);
+  auto sensor_qos_profile =
+    rclcpp::QoS(rclcpp::KeepLast(max_queue_size_), rmw_qos_profile_sensor_data);
   sub_input_filter_.subscribe(this, "input", sensor_qos_profile);
   sub_indices_filter_.subscribe(this, "indices", qos_profile);
   sub_model_.subscribe(this, "model", qos_profile);


### PR DESCRIPTION
This warning is resuling in an error on rolling dev.