### PR TITLE
Correct Statistical Outlier Removal param description

### DIFF
--- a/pcl_ros/src/pcl_ros/filters/statistical_outlier_removal.cpp
+++ b/pcl_ros/src/pcl_ros/filters/statistical_outlier_removal.cpp
@@ -71,7 +71,7 @@ pcl_ros::StatisticalOutlierRemoval::StatisticalOutlierRemoval(const rclcpp::Node
   negative_desc.name = "negative";
   negative_desc.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
   negative_desc.description =
-    "Set whether the inliers should be returned (true) or the outliers (false).";
+    "Set whether the inliers should be returned (false) or the outliers (true).";
   declare_parameter(negative_desc.name, rclcpp::ParameterValue(false), negative_desc);
 
   const std::vector<std::string> param_names {


### PR DESCRIPTION
According to the [PCL documentation](https://pcl.readthedocs.io/projects/tutorials/en/latest/statistical_outlier.html), inliers are returned when `.setNegative(false)` and outliers are returned when `.setNegative(true)`