### PR TITLE
Fix BSD-3-Cause license name in package.xml files

### DIFF
--- a/pcl_conversions/package.xml
+++ b/pcl_conversions/package.xml
@@ -13,7 +13,7 @@
   <maintainer email="www.kentaro.wada@gmail.com">Kentaro Wada</maintainer>
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url>http://wiki.ros.org/pcl_conversions</url>
   <url type="repository">https://github.com/ros-perception/perception_pcl</url>

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -15,7 +15,7 @@
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <maintainer email="www.kentaro.wada@gmail.com">Kentaro Wada</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://ros.org/wiki/perception_pcl</url>
   <url type="bugtracker">https://github.com/ros-perception/perception_pcl/issues</url>

--- a/perception_pcl/package.xml
+++ b/perception_pcl/package.xml
@@ -17,7 +17,7 @@
   <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
   <maintainer email="www.kentaro.wada@gmail.com">Kentaro Wada</maintainer>
 
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
 
   <url type="website">http://ros.org/wiki/perception_pcl</url>
   <url type="bugtracker">https://github.com/ros-perception/perception_pcl/issues</url>


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/ros-perception/pcl_msgs/pull/20 and https://github.com/ros-perception/pcl_msgs/pull/22. It updates the license name in package.xml files to be SPDX-compliant.

## Motivation and Context

Required to build Yocto images with perception-pcl packages.

## Related PRs

Yocto SDPX discussion in the meta-ros Yocto meta-layer:

* https://github.com/ros/meta-ros/issues/1208
* https://github.com/ros/meta-ros/issues/1216

## How has this been tested?

Before, Yocto builds fails.

When I manually update the three licenses to `BSD-3-Clause`, the Yocto build succeeds:

```patch
commit 0b9c34968347e4062953d93a5162949bc62eca89
Author: Garrett Brown <eigendebugger@gmail.com>
Date:   Tue Feb 3 13:47:24 2026 -0800

    perception-pcl: Fix licenses

diff --git a/recipes-ros/perception-pcl/pcl-conversions_%.bbappend b/recipes-ros/perception-pcl/pcl-conversions_%.bbappend
new file mode 100644
index 0000000..5c360db
--- /dev/null
+++ b/recipes-ros/perception-pcl/pcl-conversions_%.bbappend
@@ -0,0 +1 @@
+LICENSE = "BSD-3-Clause"
diff --git a/recipes-ros/perception-pcl/pcl-ros_%.bbappend b/recipes-ros/perception-pcl/pcl-ros_%.bbappend
new file mode 100644
index 0000000..5c360db
--- /dev/null
+++ b/recipes-ros/perception-pcl/pcl-ros_%.bbappend
@@ -0,0 +1 @@
+LICENSE = "BSD-3-Clause"
diff --git a/recipes-ros/perception-pcl/perception-pcl_%.bbappend b/recipes-ros/perception-pcl/perception-pcl_%.bbappend
new file mode 100644
index 0000000..5c360db
--- /dev/null
+++ b/recipes-ros/perception-pcl/perception-pcl_%.bbappend
@@ -0,0 +1 @@
+LICENSE = "BSD-3-Clause"
```