### PR TITLE
[Backport] Split off pcl_ros_filter into separate library (#480)

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -83,10 +83,16 @@ ament_target_dependencies(pcl_ros_tf
 #class_loader_hide_library_symbols(pcl_ros_features)
 #
 #
+
+### Declare library for base filter plugin
+add_library(pcl_ros_filter
+  src/pcl_ros/filters/filter.cpp
+)
+target_link_libraries(pcl_ros_filter pcl_ros_tf ${PCL_LIBRARIES})
+
 ### Declare the pcl_ros_filters library
 add_library(pcl_ros_filters SHARED
   src/pcl_ros/filters/extract_indices.cpp
-  src/pcl_ros/filters/filter.cpp
   src/pcl_ros/filters/passthrough.cpp
   src/pcl_ros/filters/project_inliers.cpp
   src/pcl_ros/filters/radius_outlier_removal.cpp
@@ -94,7 +100,7 @@ add_library(pcl_ros_filters SHARED
   src/pcl_ros/filters/voxel_grid.cpp
   src/pcl_ros/filters/crop_box.cpp
 )
-target_link_libraries(pcl_ros_filters pcl_ros_tf ${PCL_LIBRARIES})
+target_link_libraries(pcl_ros_filters pcl_ros_filter pcl_ros_tf ${PCL_LIBRARIES})
 ament_target_dependencies(pcl_ros_filters ${dependencies})
 rclcpp_components_register_node(pcl_ros_filters
   PLUGIN "pcl_ros::ExtractIndices"
@@ -264,6 +270,7 @@ install(
     pcd_to_pointcloud_lib
 #    pcl_ros_io
 #    pcl_ros_features
+    pcl_ros_filter
     pcl_ros_filters
 #    pcl_ros_surface
 #    pcl_ros_segmentation

--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(PCL REQUIRED QUIET COMPONENTS common features filters io segmentati
 
 ## Find ROS package dependencies
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
@@ -91,7 +92,7 @@ add_library(pcl_ros_filter
 target_link_libraries(pcl_ros_filter pcl_ros_tf ${PCL_LIBRARIES})
 
 ### Declare the pcl_ros_filters library
-add_library(pcl_ros_filters SHARED
+add_library(pcl_ros_filters
   src/pcl_ros/filters/extract_indices.cpp
   src/pcl_ros/filters/passthrough.cpp
   src/pcl_ros/filters/project_inliers.cpp
@@ -157,7 +158,7 @@ class_loader_hide_library_symbols(pcl_ros_filters)
 #
 ### Tools
 #
-add_library(pcd_to_pointcloud_lib SHARED tools/pcd_to_pointcloud.cpp)
+add_library(pcd_to_pointcloud_lib tools/pcd_to_pointcloud.cpp)
 target_link_libraries(pcd_to_pointcloud_lib
   ${PCL_LIBRARIES})
 target_include_directories(pcd_to_pointcloud_lib PUBLIC
@@ -171,7 +172,7 @@ rclcpp_components_register_node(pcd_to_pointcloud_lib
   PLUGIN "pcl_ros::PCDPublisher"
   EXECUTABLE pcd_to_pointcloud)
 
-add_library(pointcloud_to_pcd_lib SHARED tools/pointcloud_to_pcd.cpp)
+add_library(pointcloud_to_pcd_lib tools/pointcloud_to_pcd.cpp)
 target_link_libraries(pointcloud_to_pcd_lib
   pcl_ros_tf
   ${PCL_LIBRARIES})
@@ -192,7 +193,7 @@ rclcpp_components_register_node(pointcloud_to_pcd_lib
 # =====================================================
 # CombinedPointCloudToPCD Component
 # =====================================================
-add_library(combined_pointcloud_to_pcd_lib SHARED
+add_library(combined_pointcloud_to_pcd_lib
   tools/combined_pointcloud_to_pcd.cpp
 )
 

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -27,6 +27,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>ament_cmake_ros</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>

--- a/pcl_ros/tests/filters/CMakeLists.txt
+++ b/pcl_ros/tests/filters/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(ament_cmake_pytest REQUIRED)
 
 # build dummy publisher node and component
-add_library(dummy_topics SHARED
+add_library(dummy_topics
   dummy_topics.cpp
 )
 target_link_libraries(dummy_topics ${PCL_LIBRARIES})


### PR DESCRIPTION
Backports https://github.com/ros-perception/perception_pcl/pull/480
Fixes https://github.com/ros-perception/perception_pcl/issues/515