### PR TITLE
Add ament_cmake_ros to build libraries by default as SHARED

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(PCL REQUIRED QUIET COMPONENTS common features filters io segmentati
 
 ## Find ROS package dependencies
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
@@ -90,7 +91,7 @@ add_library(pcl_ros_filter
 target_link_libraries(pcl_ros_filter pcl_ros_tf ${PCL_LIBRARIES})
 
 ### Declare the pcl_ros_filters library
-add_library(pcl_ros_filters SHARED
+add_library(pcl_ros_filters
   src/pcl_ros/filters/extract_indices.cpp
   src/pcl_ros/filters/passthrough.cpp
   src/pcl_ros/filters/project_inliers.cpp
@@ -161,7 +162,7 @@ class_loader_hide_library_symbols(pcl_ros_filters)
 #
 ### Tools
 #
-add_library(pcd_to_pointcloud_lib SHARED tools/pcd_to_pointcloud.cpp)
+add_library(pcd_to_pointcloud_lib tools/pcd_to_pointcloud.cpp)
 target_include_directories(pcd_to_pointcloud_lib SYSTEM PUBLIC
   ${PCL_INCLUDE_DIRS}
 )
@@ -176,7 +177,7 @@ rclcpp_components_register_node(pcd_to_pointcloud_lib
   PLUGIN "pcl_ros::PCDPublisher"
   EXECUTABLE pcd_to_pointcloud)
 
-add_library(pointcloud_to_pcd_lib SHARED tools/pointcloud_to_pcd.cpp)
+add_library(pointcloud_to_pcd_lib tools/pointcloud_to_pcd.cpp)
 target_include_directories(pointcloud_to_pcd_lib SYSTEM PUBLIC
   ${PCL_INCLUDE_DIRS}
 )
@@ -199,7 +200,7 @@ rclcpp_components_register_node(pointcloud_to_pcd_lib
 # =====================================================
 # CombinedPointCloudToPCD Component
 # =====================================================
-add_library(combined_pointcloud_to_pcd_lib SHARED
+add_library(combined_pointcloud_to_pcd_lib
   tools/combined_pointcloud_to_pcd.cpp
 )
 
@@ -217,7 +218,7 @@ target_link_libraries(combined_pointcloud_to_pcd_lib PUBLIC
   tf2_ros::tf2_ros
 )
 
-add_library(bag_to_pcd_lib SHARED tools/bag_to_pcd.cpp)
+add_library(bag_to_pcd_lib tools/bag_to_pcd.cpp)
 target_include_directories(bag_to_pcd_lib PRIVATE
   ${PCL_INCLUDE_DIRS}
 )

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -27,6 +27,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>ament_cmake_ros</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
 
   <build_export_depend>libpcl-all-dev</build_export_depend>

--- a/pcl_ros/tests/filters/CMakeLists.txt
+++ b/pcl_ros/tests/filters/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(ament_cmake_pytest REQUIRED)
 
 # build dummy publisher node and component
-add_library(dummy_topics SHARED
+add_library(dummy_topics
   dummy_topics.cpp
 )
 target_link_libraries(dummy_topics


### PR DESCRIPTION
Previously there were some inconsistencies in the libraries, some where shared, others where static. By adding `ament_cmake_ros` everything is shared by default.