### PR TITLE
Fix rounding of nanoseconds to microseconds while converting to pcl format

### DIFF
--- a/pcl_conversions/include/pcl_conversions/pcl_conversions.h
+++ b/pcl_conversions/include/pcl_conversions/pcl_conversions.h
@@ -89,7 +89,7 @@ namespace pcl_conversions {
   inline
   void toPCL(const rclcpp::Time &stamp, std::uint64_t &pcl_stamp)
   {
-    pcl_stamp = static_cast<std::uint64_t>(stamp.nanoseconds()) / 1000ull;  // Convert from ns to us
+    pcl_stamp = static_cast<std::uint64_t>(std::round(stamp.nanoseconds() / 1000.0));  // Convert from ns to us
   }
 
   inline

--- a/pcl_conversions/test/test_pcl_conversions.cpp
+++ b/pcl_conversions/test/test_pcl_conversions.cpp
@@ -147,6 +147,34 @@ TEST(PCLConversionStamp, Stamps)
   }
 }
 
+TEST(PCLConversionStamp, ToPclNanosecondStampsRounding)
+{
+  // <500ns rounding down is 0us
+  {
+    const rclcpp::Time d(rclcpp::Time(1, 999999499));
+    std::uint64_t pcl_stamp;
+    pcl_conversions::toPCL(d, pcl_stamp);
+    EXPECT_EQ(pcl_stamp, 1999999);
+  }
+
+  // =500ns rounding down is 1us
+  {
+    const rclcpp::Time d(rclcpp::Time(1, 999999500));
+    std::uint64_t pcl_stamp;
+    pcl_conversions::toPCL(d, pcl_stamp);
+    EXPECT_EQ(pcl_stamp, 2000000);
+
+  }
+
+  // >500ns rounding up is 1us
+  {
+    const rclcpp::Time d(rclcpp::Time(1, 999999999));
+    std::uint64_t pcl_stamp;
+    pcl_conversions::toPCL(d, pcl_stamp);
+    EXPECT_EQ(pcl_stamp, 2000000);
+  }
+}
+
 int main(int argc, char **argv) {
   try {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This MR fixes this issue: https://github.com/ros-perception/perception_pcl/issues/514
Before, while converting timestamps from ROS to PCL, nanoseconds values were dropped.
Now, they are properly rounded to microseconds.