### PR TITLE
Added pointcloud_to_pcd and combined_pointcloud_to_pcd

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_eigen REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 
@@ -29,6 +30,7 @@ set(dependencies
   sensor_msgs
   geometry_msgs
   tf2
+  tf2_eigen
   tf2_geometry_msgs
   tf2_ros
   EIGEN3
@@ -133,8 +135,31 @@ rclcpp_components_register_node(pcd_to_pointcloud_lib
   PLUGIN "pcl_ros::PCDPublisher"
   EXECUTABLE pcd_to_pointcloud)
 #
-#add_executable(pointcloud_to_pcd tools/pointcloud_to_pcd.cpp)
-#target_link_libraries(pointcloud_to_pcd ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${PCL_LIBRARIES})
+add_library(pointcloud_to_pcd_lib SHARED tools/pointcloud_to_pcd.cpp)
+target_link_libraries(pointcloud_to_pcd_lib
+  pcl_ros_tf
+  ${PCL_LIBRARIES})
+target_include_directories(pointcloud_to_pcd_lib PUBLIC
+  ${PCL_INCLUDE_DIRS})
+ament_target_dependencies(pointcloud_to_pcd_lib
+  ${dependencies}
+  rclcpp_components)
+rclcpp_components_register_node(pointcloud_to_pcd_lib
+  PLUGIN "pcl_ros::PointCloudToPCD"
+  EXECUTABLE pointcloud_to_pcd)
+
+add_library(combined_pointcloud_to_pcd_lib SHARED tools/combined_pointcloud_to_pcd.cpp)
+target_link_libraries(combined_pointcloud_to_pcd_lib
+  pcl_ros_tf
+  ${PCL_LIBRARIES})
+target_include_directories(combined_pointcloud_to_pcd_lib PUBLIC
+  ${PCL_INCLUDE_DIRS})
+ament_target_dependencies(combined_pointcloud_to_pcd_lib
+  ${dependencies}
+  rclcpp_components)
+rclcpp_components_register_node(combined_pointcloud_to_pcd_lib
+  PLUGIN "pcl_ros::CombinedPointCloudToPCD"
+  EXECUTABLE combined_pointcloud_to_pcd)
 #
 #add_executable(bag_to_pcd tools/bag_to_pcd.cpp)
 #target_link_libraries(bag_to_pcd pcl_ros_tf ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${PCL_LIBRARIES})
@@ -182,6 +207,8 @@ install(
   TARGETS
     pcl_ros_tf
     pcd_to_pointcloud_lib
+    pointcloud_to_pcd_lib
+    combined_pointcloud_to_pcd_lib
 #    pcl_ros_io
 #    pcl_ros_features
 #    pcl_ros_filters

--- a/pcl_ros/package.xml
+++ b/pcl_ros/package.xml
@@ -38,6 +38,7 @@
   <depend>sensor_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
 

--- a/pcl_ros/tools/combined_pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/combined_pointcloud_to_pcd.cpp
@@ -1,0 +1,246 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2009, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * \author Radu Bogdan Rusu
+ * \author Valerio Passamano
+ *
+ * @b combined_pointcloud_to_pcd is a node that accumulates multiple incoming
+ * point cloud messages into a single PCD file, optionally transforming them
+ * into a fixed frame.
+ */
+
+#include <pcl/common/io.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <pcl_ros/transforms.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_listener.hpp>
+
+namespace pcl_ros
+{
+
+class CombinedPointCloudToPCD : public rclcpp::Node
+{
+public:
+  explicit CombinedPointCloudToPCD(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("combined_pointcloud_to_pcd", options),
+    binary_(false),
+    compressed_(false),
+    save_on_shutdown_(true),
+    fixed_frame_(""),
+    tf_buffer_(this->get_clock()),
+    tf_listener_(tf_buffer_),
+    save_triggered_(false)
+  {
+    // Declare parameters
+    this->declare_parameter<std::string>("prefix", "combined_");
+    this->declare_parameter<std::string>("fixed_frame", "");
+    this->declare_parameter<bool>("binary", false);
+    this->declare_parameter<bool>("compressed", false);
+    this->declare_parameter<bool>("save_on_shutdown", true);
+    this->declare_parameter<double>("save_timer_sec", 0.0);  // 0.0 = disabled
+
+    // Retrieve parameter values
+    prefix_ = this->get_parameter("prefix").as_string();
+    fixed_frame_ = this->get_parameter("fixed_frame").as_string();
+    binary_ = this->get_parameter("binary").as_bool();
+    compressed_ = this->get_parameter("compressed").as_bool();
+    save_on_shutdown_ = this->get_parameter("save_on_shutdown").as_bool();
+    double save_timer_sec = this->get_parameter("save_timer_sec").as_double();
+
+    RCLCPP_INFO(this->get_logger(), "prefix: %s", prefix_.c_str());
+    RCLCPP_INFO(this->get_logger(), "fixed_frame: %s", fixed_frame_.c_str());
+    RCLCPP_INFO(this->get_logger(), "binary: %s", binary_ ? "true" : "false");
+    RCLCPP_INFO(this->get_logger(), "compressed: %s", compressed_ ? "true" : "false");
+    RCLCPP_INFO(this->get_logger(), "save_on_shutdown: %s", save_on_shutdown_ ? "true" : "false");
+    if (save_timer_sec > 0.0) {
+      RCLCPP_INFO(
+        this->get_logger(),
+        "PCD file will be automatically saved after %.2f seconds (save_timer_sec).",
+        save_timer_sec);
+    } else {
+      RCLCPP_INFO(
+        this->get_logger(),
+        "PCD file will not be automatically saved. Will be saved on the shutdown of the node.");
+    }
+
+    // Create a subscription with SensorDataQoS
+    auto sensor_qos = rclcpp::SensorDataQoS();
+    sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
+      "input", sensor_qos,
+      std::bind(&CombinedPointCloudToPCD::cloudCb, this, std::placeholders::_1));
+
+    // Create a timer if the user wants a periodic check for saving
+    if (save_timer_sec > 0.0) {
+      save_timer_ = this->create_wall_timer(
+        std::chrono::duration<double>(save_timer_sec),
+        std::bind(&CombinedPointCloudToPCD::checkAndSave, this));
+    }
+
+    RCLCPP_INFO(this->get_logger(), "Initialized CombinedPointCloudToPCD node");
+  }
+
+  ~CombinedPointCloudToPCD() override
+  {
+    // Optionally save on node shutdown
+    if (!save_triggered_ && save_on_shutdown_) {
+      RCLCPP_INFO(this->get_logger(), "Node is shutting down; saving accumulated cloud.");
+      saveAccumulatedCloud();
+    }
+  }
+
+private:
+  // Parameters
+  std::string prefix_;
+  bool binary_;
+  bool compressed_;
+  bool save_on_shutdown_;
+  std::string fixed_frame_;
+
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_;
+  rclcpp::TimerBase::SharedPtr save_timer_;
+
+  // Internal state
+  pcl::PCLPointCloud2 accumulated_cloud_;
+  bool save_triggered_;
+
+  /**
+   * @brief Point cloud callback. Accumulates all incoming messages in an internal cloud.
+   */
+  void cloudCb(const sensor_msgs::msg::PointCloud2::SharedPtr cloud_msg)
+  {
+    if (cloud_msg->data.empty()) {
+      RCLCPP_WARN(this->get_logger(), "Received empty point cloud message. Skipping.");
+      return;
+    }
+
+    pcl::PCLPointCloud2 pcl_pc2;
+
+    if (!fixed_frame_.empty()) {
+      sensor_msgs::msg::PointCloud2 transformed_ros;
+      if (pcl_ros::transformPointCloud(fixed_frame_, *cloud_msg, transformed_ros, tf_buffer_)) {
+        pcl_conversions::toPCL(transformed_ros, pcl_pc2);
+      } else {
+        RCLCPP_WARN(
+          this->get_logger(), "Transform to frame '%s' failed. Using original frame.",
+          fixed_frame_.c_str());
+        pcl_conversions::toPCL(*cloud_msg, pcl_pc2);
+      }
+    } else {
+      pcl_conversions::toPCL(*cloud_msg, pcl_pc2);
+    }
+
+    if (accumulated_cloud_.data.empty()) {
+      accumulated_cloud_ = pcl_pc2;
+    } else {
+      accumulated_cloud_.data.insert(
+        accumulated_cloud_.data.end(),
+        pcl_pc2.data.begin(),
+        pcl_pc2.data.end());
+      accumulated_cloud_.width += pcl_pc2.width;
+      accumulated_cloud_.row_step =
+        accumulated_cloud_.point_step * accumulated_cloud_.width;
+    }
+
+    RCLCPP_INFO(
+      this->get_logger(), "Accumulated cloud size: %u",
+      accumulated_cloud_.width * accumulated_cloud_.height);
+  }
+
+  /**
+   * @brief Timer-based or event-based function to check if we need to save the cloud.
+   */
+  void checkAndSave()
+  {
+    if (!save_triggered_) {
+      saveAccumulatedCloud();
+    }
+  }
+
+  /**
+   * @brief Writes the accumulated point cloud to disk in a single PCD file.
+   */
+  void saveAccumulatedCloud()
+  {
+    if (save_triggered_) {
+      return;
+    }
+    save_triggered_ = true;  // Prevent multiple saves
+
+    // Create a filename
+    std::stringstream ss;
+    ss << prefix_ << "combined_" << this->now().seconds() << ".pcd";
+    std::string filename = ss.str();
+
+    RCLCPP_INFO(this->get_logger(), "Saving accumulated point cloud to: %s", filename.c_str());
+
+    if (accumulated_cloud_.data.empty()) {
+      RCLCPP_WARN(this->get_logger(), "No points in accumulated cloud to save.");
+    } else {
+      pcl::PCDWriter writer;
+      if (binary_) {
+        if (compressed_) {
+          writer.writeBinaryCompressed(filename, accumulated_cloud_);
+        } else {
+          writer.writeBinary(filename, accumulated_cloud_);
+        }
+      } else {
+        writer.writeASCII(filename, accumulated_cloud_);
+      }
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Saved %u points to %s",
+        accumulated_cloud_.width * accumulated_cloud_.height,
+        filename.c_str());
+    }
+    // Shut down the node after saving the cloud.
+    RCLCPP_INFO(this->get_logger(), "Shutting down the node.");
+    rclcpp::shutdown();
+  }
+};
+
+}  // namespace pcl_ros
+
+// Register as a component
+RCLCPP_COMPONENTS_REGISTER_NODE(pcl_ros::CombinedPointCloudToPCD)

--- a/pcl_ros/tools/pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/pointcloud_to_pcd.cpp
@@ -35,27 +35,6 @@
  *
  */
 
-// ROS core
-#include <ros/ros.h>
-
-#include <sensor_msgs/PointCloud2.h>
-
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
-#include <tf2_eigen/tf2_eigen.h>
-
-// PCL includes
-#include <pcl/io/io.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-
-#include <pcl_conversions/pcl_conversions.h>
-
-#include <Eigen/Geometry>
-
-// STL
-#include <string>
-
 /**
 \author Radu Bogdan Rusu
 
@@ -63,122 +42,116 @@
 Cloud Data) file format.
 
 **/
-class PointCloudToPCD
-{
-protected:
-  ros::NodeHandle nh_;
 
+#include <pcl/common/io.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <pcl_ros/transforms.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_listener.hpp>
+
+namespace pcl_ros
+{
+
+class PointCloudToPCD : public rclcpp::Node
+{
 private:
   std::string prefix_;
   bool binary_;
   bool compressed_;
   std::string fixed_frame_;
+  bool use_transform_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
 public:
-  std::string cloud_topic_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_;
 
-  ros::Subscriber sub_;
-
-  ////////////////////////////////////////////////////////////////////////////////
-  // Callback
-  void
-  cloud_cb(const boost::shared_ptr<const pcl::PCLPointCloud2> & cloud)
+  void cloud_cb(const sensor_msgs::msg::PointCloud2::SharedPtr cloud_msg)
   {
-    if ((cloud->width * cloud->height) == 0) {
+    if (cloud_msg->data.empty()) {
+      RCLCPP_ERROR(this->get_logger(), "Received empty point cloud message!");
       return;
     }
 
-    ROS_INFO(
-      "Received %d data points in frame %s with the following fields: %s",
-      (int)cloud->width * cloud->height,
-      cloud->header.frame_id.c_str(),
-      pcl::getFieldsList(*cloud).c_str());
-
-    Eigen::Vector4f v = Eigen::Vector4f::Zero();
-    Eigen::Quaternionf q = Eigen::Quaternionf::Identity();
+    sensor_msgs::msg::PointCloud2 transformed_cloud;
     if (!fixed_frame_.empty()) {
-      if (!tf_buffer_.canTransform(
-          fixed_frame_, cloud->header.frame_id,
-          pcl_conversions::fromPCL(cloud->header.stamp), ros::Duration(3.0)))
-      {
-        ROS_WARN("Could not get transform!");
-        return;
-      }
-
-      Eigen::Affine3d transform;
-      transform =
-        tf2::transformToEigen(
-        tf_buffer_.lookupTransform(
-          fixed_frame_, cloud->header.frame_id,
-          pcl_conversions::fromPCL(cloud->header.stamp)));
-      v = Eigen::Vector4f::Zero();
-      v.head<3>() = transform.translation().cast<float>();
-      q = transform.rotation().cast<float>();
+      use_transform_ = pcl_ros::transformPointCloud(
+        fixed_frame_, *cloud_msg, transformed_cloud,
+        tf_buffer_);
+    } else {
+      use_transform_ = false;
     }
 
     std::stringstream ss;
-    ss << prefix_ << cloud->header.stamp << ".pcd";
-    ROS_INFO("Data saved to %s", ss.str().c_str());
+    ss << prefix_ << cloud_msg->header.stamp.sec << "."
+       << std::setw(9) << std::setfill('0') << cloud_msg->header.stamp.nanosec
+       << ".pcd";
+    RCLCPP_INFO(this->get_logger(), "Writing to %s", ss.str().c_str());
 
+    pcl::PCLPointCloud2 pcl_pc2;
+    if (use_transform_) {
+      pcl_conversions::toPCL(transformed_cloud, pcl_pc2);
+    } else {
+      pcl_conversions::toPCL(*cloud_msg, pcl_pc2);
+    }
+
+    writePCDFile(ss.str(), pcl_pc2);
+  }
+
+  void writePCDFile(const std::string & filename, const pcl::PCLPointCloud2 & cloud)
+  {
     pcl::PCDWriter writer;
     if (binary_) {
       if (compressed_) {
-        writer.writeBinaryCompressed(ss.str(), *cloud, v, q);
+        writer.writeBinaryCompressed(filename, cloud);
       } else {
-        writer.writeBinary(ss.str(), *cloud, v, q);
+        writer.writeBinary(filename, cloud);
       }
     } else {
-      writer.writeASCII(ss.str(), *cloud, v, q, 8);
+      // Default precision is 8
+      writer.writeASCII(filename, cloud);
     }
   }
 
   ////////////////////////////////////////////////////////////////////////////////
-  PointCloudToPCD()
-  : binary_(false), compressed_(false), tf_listener_(tf_buffer_)
+  explicit PointCloudToPCD(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("pointcloud_to_pcd", options),
+    binary_(false), compressed_(false),
+    tf_buffer_(this->get_clock()), tf_listener_(tf_buffer_)
   {
-    // Check if a prefix parameter is defined for output file names.
-    ros::NodeHandle priv_nh("~");
-    if (priv_nh.getParam("prefix", prefix_)) {
-      ROS_INFO_STREAM("PCD file prefix is: " << prefix_);
-    } else if (nh_.getParam("prefix", prefix_)) {
-      ROS_WARN_STREAM(
-        "Non-private PCD prefix parameter is DEPRECATED: " <<
-          prefix_);
-    }
+    this->declare_parameter("prefix", prefix_);
+    this->declare_parameter("fixed_frame", fixed_frame_);
+    this->declare_parameter("binary", binary_);
+    this->declare_parameter("compressed", compressed_);
 
-    priv_nh.getParam("fixed_frame", fixed_frame_);
-    priv_nh.getParam("binary", binary_);
-    priv_nh.getParam("compressed", compressed_);
-    if (binary_) {
-      if (compressed_) {
-        ROS_INFO_STREAM("Saving as binary compressed PCD");
-      } else {
-        ROS_INFO_STREAM("Saving as binary PCD");
-      }
-    } else {
-      ROS_INFO_STREAM("Saving as binary PCD");
-    }
+    this->get_parameter("prefix", prefix_);
+    this->get_parameter("fixed_frame", fixed_frame_);
+    this->get_parameter("binary", binary_);
+    this->get_parameter("compressed", compressed_);
 
-    cloud_topic_ = "input";
+    // Enable QoS reconfigurability via parameters
+    rclcpp::SubscriptionOptions sub_options;
+    sub_options.qos_overriding_options =
+      rclcpp::QosOverridingOptions {{
+      rclcpp::QosPolicyKind::History,
+      rclcpp::QosPolicyKind::Reliability,
+      rclcpp::QosPolicyKind::Durability,
+      rclcpp::QosPolicyKind::Depth
+    }};
 
-    sub_ = nh_.subscribe(cloud_topic_, 1, &PointCloudToPCD::cloud_cb, this);
-    ROS_INFO(
-      "Listening for incoming data on topic %s",
-      nh_.resolveName(cloud_topic_).c_str());
+    auto sensor_qos = rclcpp::SensorDataQoS();
+    sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
+      "input", sensor_qos,
+      std::bind(&PointCloudToPCD::cloud_cb, this, std::placeholders::_1), sub_options);
   }
 };
+}  // namespace pcl_ros
 
-/* ---[ */
-int
-main(int argc, char ** argv)
-{
-  ros::init(argc, argv, "pointcloud_to_pcd", ros::init_options::AnonymousName);
-
-  PointCloudToPCD b;
-  ros::spin();
-
-  return 0;
-}
-/* ]--- */
+RCLCPP_COMPONENTS_REGISTER_NODE(pcl_ros::PointCloudToPCD)


### PR DESCRIPTION
`pointcloud_to_pcd` was broken on the `humble` branch as the source file was still ROS 1 code and the CMakeLists.txt entry was commented out. `combined_pointcloud_to_pcd` (available in the `ros2` branch) was also missing from `humble`.

## CHANGES
**`pointcloud_to_pcd.cpp`** - ported from ROS 1 to ROS 2:
**`combined_pointcloud_to_pcd.cpp`** - backported from `ros2` branch with two adaptations for Humble:
**`CMakeLists.txt`** - adds both tools as shared libs using `rclcpp_components_register_node`
**`package.xml`** - adds `tf2_eigen` dependency
