### PR TITLE
fix(pcl_ros): preserve all fields in combined_pointcloud_to_pcd

### DIFF
--- a/pcl_ros/CMakeLists.txt
+++ b/pcl_ros/CMakeLists.txt
@@ -212,10 +212,9 @@ target_link_libraries(combined_pointcloud_to_pcd_lib PUBLIC
   ${PCL_LIBRARIES}
   ${sensor_msgs_TARGETS}
   pcl_conversions::pcl_conversions
+  pcl_ros_tf
   rclcpp::rclcpp
   rclcpp_components::component
-  tf2_eigen::tf2_eigen
-  tf2_ros::tf2_ros
 )
 
 add_library(bag_to_pcd_lib tools/bag_to_pcd.cpp)

--- a/pcl_ros/tools/combined_pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/combined_pointcloud_to_pcd.cpp
@@ -130,7 +130,7 @@ public:
     // Optionally save on node shutdown (do not call rclcpp::shutdown from destructor)
     if (!save_triggered_ && save_on_shutdown_) {
       RCLCPP_INFO(this->get_logger(), "Node is shutting down; saving accumulated cloud.");
-      saveAccumulatedCloud(false);
+      saveAccumulatedCloud();
     }
   }
 
@@ -202,15 +202,16 @@ private:
   void checkAndSave()
   {
     if (!save_triggered_) {
-      saveAccumulatedCloud(true);
+      saveAccumulatedCloud();
+      RCLCPP_INFO(this->get_logger(), "Shutting down the node.");
+      rclcpp::shutdown();
     }
   }
 
   /**
    * @brief Writes the accumulated point cloud to disk in a single PCD file.
-   * \param do_shutdown if true, calls rclcpp::shutdown() after saving.
    */
-  void saveAccumulatedCloud(bool do_shutdown = true)
+  void saveAccumulatedCloud()
   {
     if (save_triggered_) {
       return;
@@ -242,10 +243,6 @@ private:
         "Saved %u points to %s",
         accumulated_cloud_.width * accumulated_cloud_.height,
         filename.c_str());
-    }
-    if (do_shutdown) {
-      RCLCPP_INFO(this->get_logger(), "Shutting down the node.");
-      rclcpp::shutdown();
     }
   }
 };

--- a/pcl_ros/tools/combined_pointcloud_to_pcd.cpp
+++ b/pcl_ros/tools/combined_pointcloud_to_pcd.cpp
@@ -41,15 +41,17 @@
  * into a fixed frame.
  */
 
-#include <pcl/common/io.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <chrono>
+#include <sstream>
+#include <string>
+
+#include <pcl_ros/transforms.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_ros/buffer.hpp>
 #include <tf2_ros/transform_listener.hpp>
 
@@ -63,8 +65,6 @@ public:
   : rclcpp::Node("combined_pointcloud_to_pcd", options),
     binary_(false),
     compressed_(false),
-    rgb_(false),
-    use_transform_(false),
     save_on_shutdown_(true),
     fixed_frame_(""),
     tf_buffer_(this->get_clock()),
@@ -72,11 +72,11 @@ public:
     save_triggered_(false)
   {
     // Declare parameters
-    this->declare_parameter<std::string>("prefix", "combined_");
+    this->declare_parameter<std::string>("prefix", "");
     this->declare_parameter<std::string>("fixed_frame", "");
     this->declare_parameter<bool>("binary", false);
     this->declare_parameter<bool>("compressed", false);
-    this->declare_parameter<bool>("rgb", false);
+    this->declare_parameter<bool>("rgb", false);  // deprecated: all fields are preserved
     this->declare_parameter<bool>("save_on_shutdown", true);
     this->declare_parameter<double>("save_timer_sec", 0.0);  // 0.0 = disabled
 
@@ -85,15 +85,18 @@ public:
     fixed_frame_ = this->get_parameter("fixed_frame").as_string();
     binary_ = this->get_parameter("binary").as_bool();
     compressed_ = this->get_parameter("compressed").as_bool();
-    rgb_ = this->get_parameter("rgb").as_bool();
     save_on_shutdown_ = this->get_parameter("save_on_shutdown").as_bool();
     double save_timer_sec = this->get_parameter("save_timer_sec").as_double();
+    if (this->get_parameter("rgb").as_bool()) {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Parameter 'rgb' is deprecated and has no effect: all fields are preserved.");
+    }
 
     RCLCPP_INFO(this->get_logger(), "prefix: %s", prefix_.c_str());
     RCLCPP_INFO(this->get_logger(), "fixed_frame: %s", fixed_frame_.c_str());
     RCLCPP_INFO(this->get_logger(), "binary: %s", binary_ ? "true" : "false");
     RCLCPP_INFO(this->get_logger(), "compressed: %s", compressed_ ? "true" : "false");
-    RCLCPP_INFO(this->get_logger(), "rgb: %s", rgb_ ? "true" : "false");
     RCLCPP_INFO(this->get_logger(), "save_on_shutdown: %s", save_on_shutdown_ ? "true" : "false");
     if (save_timer_sec > 0.0) {
       RCLCPP_INFO(
@@ -124,10 +127,10 @@ public:
 
   ~CombinedPointCloudToPCD() override
   {
-    // Optionally save on node shutdown
+    // Optionally save on node shutdown (do not call rclcpp::shutdown from destructor)
     if (!save_triggered_ && save_on_shutdown_) {
       RCLCPP_INFO(this->get_logger(), "Node is shutting down; saving accumulated cloud.");
-      saveAccumulatedCloud();
+      saveAccumulatedCloud(false);
     }
   }
 
@@ -136,8 +139,6 @@ private:
   std::string prefix_;
   bool binary_;
   bool compressed_;
-  bool rgb_;
-  bool use_transform_;
   bool save_on_shutdown_;
   std::string fixed_frame_;
 
@@ -148,8 +149,7 @@ private:
   rclcpp::TimerBase::SharedPtr save_timer_;
 
   // Internal state
-  pcl::PointCloud<pcl::PointXYZ> accumulated_cloud_xyz_;
-  pcl::PointCloud<pcl::PointXYZRGB> accumulated_cloud_xyzrgb_;
+  pcl::PCLPointCloud2 accumulated_cloud_;
   bool save_triggered_;
 
   /**
@@ -162,87 +162,38 @@ private:
       return;
     }
 
-    // Attempt transform if fixed_frame_ is set
-    Eigen::Vector4f translation = Eigen::Vector4f::Zero();
-    Eigen::Quaternionf rotation = Eigen::Quaternionf::Identity();
-    use_transform_ = false;
+    pcl::PCLPointCloud2 pcl_pc2;
 
     if (!fixed_frame_.empty()) {
-      try {
-        geometry_msgs::msg::TransformStamped transform =
-          tf_buffer_.lookupTransform(
-          fixed_frame_, cloud_msg->header.frame_id, cloud_msg->header.stamp);
-
-        Eigen::Affine3d transform_eigen = tf2::transformToEigen(transform);
-        translation.head<3>() = transform_eigen.translation().cast<float>();
-        rotation = transform_eigen.rotation().cast<float>();
-        use_transform_ = true;
-      } catch (tf2::TransformException & ex) {
+      sensor_msgs::msg::PointCloud2 transformed_ros;
+      if (!pcl_ros::transformPointCloud(fixed_frame_, *cloud_msg, transformed_ros, tf_buffer_)) {
         RCLCPP_WARN(
-          this->get_logger(), "Transform to frame '%s' failed: %s. Using original frame.",
-          fixed_frame_.c_str(), ex.what());
-        use_transform_ = false;
+          this->get_logger(),
+          "Transform to frame '%s' failed. Skipping cloud to avoid mixing frames.",
+          fixed_frame_.c_str());
+        return;
       }
-    }
-
-    // Convert ROS msg to PCL
-    if (rgb_) {
-      pcl::PointCloud<pcl::PointXYZRGB> pcl_cloud;
-      pcl::fromROSMsg(*cloud_msg, pcl_cloud);
-
-      if (use_transform_) {
-        transformPointCloud(pcl_cloud, translation, rotation);
-      }
-      // Accumulate
-      accumulated_cloud_xyzrgb_ += pcl_cloud;
-      RCLCPP_INFO(
-        this->get_logger(), "Accumulated (XYZRGB) cloud size: %zu",
-        accumulated_cloud_xyzrgb_.size());
+      pcl_conversions::toPCL(transformed_ros, pcl_pc2);
     } else {
-      pcl::PointCloud<pcl::PointXYZ> pcl_cloud;
-      pcl::fromROSMsg(*cloud_msg, pcl_cloud);
+      pcl_conversions::toPCL(*cloud_msg, pcl_pc2);
+    }
 
-      if (use_transform_) {
-        transformPointCloud(pcl_cloud, translation, rotation);
+    if (accumulated_cloud_.data.empty()) {
+      accumulated_cloud_ = pcl_pc2;
+    } else {
+      if (!pcl::PCLPointCloud2::concatenate(accumulated_cloud_, pcl_pc2)) {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Cloud schema mismatch (fields/endianness differ). Skipping cloud.");
+        return;
       }
-      // Accumulate
-      accumulated_cloud_xyz_ += pcl_cloud;
-      RCLCPP_INFO(
-        this->get_logger(), "Accumulated (XYZ) cloud size: %zu",
-        accumulated_cloud_xyz_.size());
+      accumulated_cloud_.is_dense =
+        static_cast<uint8_t>(accumulated_cloud_.is_dense && pcl_pc2.is_dense);
     }
-  }
 
-  /**
-   * @brief Apply a rigid transform (translation + rotation) to an XYZ cloud in-place.
-   */
-  void transformPointCloud(
-    pcl::PointCloud<pcl::PointXYZ> & cloud_inout,
-    const Eigen::Vector4f & translation,
-    const Eigen::Quaternionf & rotation)
-  {
-    for (auto & pt : cloud_inout.points) {
-      Eigen::Vector3f v = rotation * pt.getVector3fMap() + translation.head<3>();
-      pt.x = v.x();
-      pt.y = v.y();
-      pt.z = v.z();
-    }
-  }
-
-  /**
-   * @brief Apply a rigid transform (translation + rotation) to an XYZRGB cloud in-place.
-   */
-  void transformPointCloud(
-    pcl::PointCloud<pcl::PointXYZRGB> & cloud_inout,
-    const Eigen::Vector4f & translation,
-    const Eigen::Quaternionf & rotation)
-  {
-    for (auto & pt : cloud_inout.points) {
-      Eigen::Vector3f v = rotation * pt.getVector3fMap() + translation.head<3>();
-      pt.x = v.x();
-      pt.y = v.y();
-      pt.z = v.z();
-    }
+    RCLCPP_INFO(
+      this->get_logger(), "Accumulated cloud size: %u",
+      accumulated_cloud_.width * accumulated_cloud_.height);
   }
 
   /**
@@ -251,14 +202,15 @@ private:
   void checkAndSave()
   {
     if (!save_triggered_) {
-      saveAccumulatedCloud();
+      saveAccumulatedCloud(true);
     }
   }
 
   /**
    * @brief Writes the accumulated point cloud to disk in a single PCD file.
+   * \param do_shutdown if true, calls rclcpp::shutdown() after saving.
    */
-  void saveAccumulatedCloud()
+  void saveAccumulatedCloud(bool do_shutdown = true)
   {
     if (save_triggered_) {
       return;
@@ -267,57 +219,34 @@ private:
 
     // Create a filename
     std::stringstream ss;
-    ss << prefix_ << "combined_" << this->now().seconds() << ".pcd";
+    ss << prefix_ << "combined_" << this->now().nanoseconds() << ".pcd";
     std::string filename = ss.str();
 
     RCLCPP_INFO(this->get_logger(), "Saving accumulated point cloud to: %s", filename.c_str());
 
-    pcl::PCDWriter writer;
-
-    if (rgb_) {
-      if (accumulated_cloud_xyzrgb_.empty()) {
-        RCLCPP_WARN(this->get_logger(), "No points in accumulated XYZRGB cloud to save.");
-      } else {
-        if (binary_) {
-          if (compressed_) {
-            writer.writeBinaryCompressed(filename, accumulated_cloud_xyzrgb_);
-          } else {
-            writer.writeBinary(filename, accumulated_cloud_xyzrgb_);
-          }
-        } else {
-          writer.writeASCII(filename, accumulated_cloud_xyzrgb_, 8);
-        }
-        RCLCPP_INFO(
-          this->get_logger(),
-          "Saved %zu XYZRGB points to %s",
-          accumulated_cloud_xyzrgb_.size(),
-          filename.c_str()
-        );
-      }
+    if (accumulated_cloud_.data.empty()) {
+      RCLCPP_WARN(this->get_logger(), "No points in accumulated cloud to save.");
     } else {
-      if (accumulated_cloud_xyz_.empty()) {
-        RCLCPP_WARN(this->get_logger(), "No points in accumulated XYZ cloud to save.");
-      } else {
-        if (binary_) {
-          if (compressed_) {
-            writer.writeBinaryCompressed(filename, accumulated_cloud_xyz_);
-          } else {
-            writer.writeBinary(filename, accumulated_cloud_xyz_);
-          }
+      pcl::PCDWriter writer;
+      if (binary_) {
+        if (compressed_) {
+          writer.writeBinaryCompressed(filename, accumulated_cloud_);
         } else {
-          writer.writeASCII(filename, accumulated_cloud_xyz_, 8);
+          writer.writeBinary(filename, accumulated_cloud_);
         }
-        RCLCPP_INFO(
-          this->get_logger(),
-          "Saved %zu XYZ points to %s",
-          accumulated_cloud_xyz_.size(),
-          filename.c_str()
-        );
+      } else {
+        writer.writeASCII(filename, accumulated_cloud_);
       }
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Saved %u points to %s",
+        accumulated_cloud_.width * accumulated_cloud_.height,
+        filename.c_str());
     }
-    // Shut down the node after saving the cloud.
-    RCLCPP_INFO(this->get_logger(), "Shutting down the node.");
-    rclcpp::shutdown();
+    if (do_shutdown) {
+      RCLCPP_INFO(this->get_logger(), "Shutting down the node.");
+      rclcpp::shutdown();
+    }
   }
 };
 


### PR DESCRIPTION
`combined_pointcloud_to_pcd` was accumulating clouds into typed
`pcl::PointCloud<pcl::PointXYZ>` / `pcl::PointCloud<pcl::PointXYZRGB>`
containers, silently dropping all extra fields (intensity, ring,
timestamps, custom fields, etc.) on every incoming message.

This applies the same approach used in `pointcloud_to_pcd` since #491:
replace the typed accumulators with a single `pcl::PCLPointCloud2` so
all fields are preserved as-is.

The TF transform path also needed to change: typed
clouds allowed manual Eigen loops over `.points`, which is not possible
with `PCLPointCloud2`. The fix uses `pcl_ros::transformPointCloud` (same
as `pointcloud_to_pcd`). With per-cloud TF, failing silently and falling
back to the original frame would mix coordinate frames in the output, so
the node now skips the cloud and logs a warning instead.

Other changes:
- `pcl::PCLPointCloud2::concatenate` replaces manual buffer append,
  adding schema validation (skips cloudds with mismatched fields or endianness)
- `rgb` parameter is kept but marked deprecated
- `is_dense` propagated as logical AND across accumulated clouds
- `pcl_ros_tf` added to link dependencies; `tf2_eigen` and direct
  `tf2_ros` removed (transitively provided by `pcl_ros_tf`)
- Fixed filename bug: prefix `"combined_"` was producing
  `combined_combined_*.pcd`
- `rclcpp::shutdown()` no longer called from destructor (passed via
  `do_shutdown` flag to avoid UB)