### PR TITLE
pcl_conversions: Fix compile errors caused by rosidl_buffer introduction

### DIFF
--- a/pcl_conversions/include/pcl_conversions/pcl_conversions.h
+++ b/pcl_conversions/include/pcl_conversions/pcl_conversions.h
@@ -169,7 +169,7 @@ namespace pcl_conversions {
   void moveFromPCL(pcl::PCLImage &pcl_image, sensor_msgs::msg::Image &image)
   {
     copyPCLImageMetaData(pcl_image, image);
-    image.data.swap(pcl_image.data);
+    static_cast<std::vector<uint8_t>&>(image.data).swap(pcl_image.data);
   }
 
   inline
@@ -194,7 +194,7 @@ namespace pcl_conversions {
   void moveToPCL(sensor_msgs::msg::Image &image, pcl::PCLImage &pcl_image)
   {
     copyImageMetaData(image, pcl_image);
-    pcl_image.data.swap(image.data);
+    pcl_image.data.swap(static_cast<std::vector<uint8_t>&>(image.data));
   }
 
   /** PCLPointField <=> PointField **/
@@ -269,7 +269,7 @@ namespace pcl_conversions {
   void moveFromPCL(pcl::PCLPointCloud2 &pcl_pc2, sensor_msgs::msg::PointCloud2 &pc2)
   {
     copyPCLPointCloud2MetaData(pcl_pc2, pc2);
-    pc2.data.swap(pcl_pc2.data);
+    static_cast<std::vector<uint8_t>&>(pc2.data).swap(pcl_pc2.data);
   }
 
   inline


### PR DESCRIPTION
Compiling `pcl_ros` package in rolling results in errors like this:

    In file included from
    /build/perception_pcl-release-release-rolling-pcl_ros-2.8.0-1/tools/combined_pointcloud_to_pcd.cpp:47:
    /ros-rolling-pcl-conversions-2.8.0-r1/include/pcl_conversions/pcl_conversions/pcl_conversions.h: In
      function 'void pcl_conversions::moveFromPCL(pcl::PCLImage&, sensor_msgs::msg::Image&)':
    /ros-rolling-pcl-conversions-2.8.0-r1/include/pcl_conversions/pcl_conversions/pcl_conversions.h:172:16:
      error: 'using sensor_msgs::msg::Image_<std::allocator<void> >::_data_type = class
      rosidl::Buffer<unsigned char, std::allocator<unsigned char> >' {aka 'class rosidl::Buffer<unsigned
      char, std::allocator<unsigned char> >'} has no member named 'swap'
      172 |     image.data.swap(pcl_image.data);
          |                ^~~~

These are caused by https://github.com/ros2/rosidl/pull/941 and followup PRs, which change the type of `uint8[]` message fields from `std::vector<uint8_t>` to `rosidl::Buffer<uint8_t>`. To maintain the previous functionality, explicit typecasting is needed at a few places. This causes invocation of the [conversion operator][1], which returns a reference to the underlying std::vector.

[1]: https://github.com/ros2/rosidl/blob/7c4e0f90f2979c16c906d65058fc7966360f52e1/rosidl_buffer/include/rosidl_buffer/buffer.hpp#L420