### PR TITLE
Remove unused find_package(Boost)

### DIFF
--- a/pcl_conversions/CMakeLists.txt
+++ b/pcl_conversions/CMakeLists.txt
@@ -11,7 +11,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(Boost REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(PCL REQUIRED QUIET COMPONENTS common io)


### PR DESCRIPTION
`pcl_conversions` calls `find_package(Boost)`, but it doesn't use any variables or targets from it. This PR removes it. This should fix the build on RHEL 10.