### PR TITLE
Replace transform exceptions with the base tf2::TransformException

### DIFF
--- a/pcl_ros/src/transforms.cpp
+++ b/pcl_ros/src/transforms.cpp
@@ -78,10 +78,7 @@ transformPointCloud(
       tf_buffer.lookupTransform(
       target_frame, in.header.frame_id, tf2_ros::fromMsg(
         in.header.stamp), tf2::Duration(std::chrono::seconds(1)));
-  } catch (tf2::LookupException & e) {
-    RCLCPP_ERROR(rclcpp::get_logger("pcl_ros"), "%s", e.what());
-    return false;
-  } catch (tf2::ExtrapolationException & e) {
+  } catch (tf2::TransformException & e) {
     RCLCPP_ERROR(rclcpp::get_logger("pcl_ros"), "%s", e.what());
     return false;
   }


### PR DESCRIPTION
Currently the tf2 exceptions are explicitly set to `tf2::LookupException` and `tf2::ExtrapolationException`. However, there could be more exceptions as mentioned in https://github.com/ros2/geometry2/blob/rolling/tf2/include/tf2/exceptions.hpp.

I believe it is better to use the base `tf2::TransformException` instead of explicitly adjusting the list every time.