### PR TITLE
[pcl_ros] Jazzy backport - Replace exceptions with the base tf2::TransformException (#532)

### DIFF
--- a/pcl_ros/src/transforms.cpp
+++ b/pcl_ros/src/transforms.cpp
@@ -78,10 +78,7 @@ transformPointCloud(
       tf_buffer.lookupTransform(
       target_frame, in.header.frame_id, tf2_ros::fromMsg(
         in.header.stamp), tf2::Duration(std::chrono::seconds(1)));
-  } catch (tf2::LookupException & e) {
-    RCLCPP_ERROR(rclcpp::get_logger("pcl_ros"), "%s", e.what());
-    return false;
-  } catch (tf2::ExtrapolationException & e) {
+  } catch (tf2::TransformException & e) {
     RCLCPP_ERROR(rclcpp::get_logger("pcl_ros"), "%s", e.what());
     return false;
   }


### PR DESCRIPTION
Backport of https://github.com/ros-perception/perception_pcl/pull/532 into Jazzy