### PR TITLE
Integer arithmetic time rounding

### DIFF
--- a/pcl_conversions/include/pcl_conversions/pcl_conversions.h
+++ b/pcl_conversions/include/pcl_conversions/pcl_conversions.h
@@ -89,7 +89,7 @@ namespace pcl_conversions {
   inline
   void toPCL(const rclcpp::Time &stamp, std::uint64_t &pcl_stamp)
   {
-    pcl_stamp = static_cast<std::uint64_t>(std::round(stamp.nanoseconds() / 1000.0));  // Convert from ns to us
+    pcl_stamp = (stamp.nanoseconds() + 500ull) / 1000;  // Round to nearest microsecond
   }
 
   inline

--- a/pcl_conversions/test/test_pcl_conversions.cpp
+++ b/pcl_conversions/test/test_pcl_conversions.cpp
@@ -151,27 +151,27 @@ TEST(PCLConversionStamp, ToPclNanosecondStampsRounding)
 {
   // <500ns rounding down is 0us
   {
-    const rclcpp::Time d(rclcpp::Time(1, 999999499));
+    const rclcpp::Time d(rclcpp::Time(1000000000, 999999499));
     std::uint64_t pcl_stamp;
     pcl_conversions::toPCL(d, pcl_stamp);
-    EXPECT_EQ(pcl_stamp, 1999999);
+    EXPECT_EQ(pcl_stamp, 1000000000999999);
   }
 
   // =500ns rounding down is 1us
   {
-    const rclcpp::Time d(rclcpp::Time(1, 999999500));
+    const rclcpp::Time d(rclcpp::Time(1000000000, 999999500));
     std::uint64_t pcl_stamp;
     pcl_conversions::toPCL(d, pcl_stamp);
-    EXPECT_EQ(pcl_stamp, 2000000);
+    EXPECT_EQ(pcl_stamp, 1000000001000000);
 
   }
 
   // >500ns rounding up is 1us
   {
-    const rclcpp::Time d(rclcpp::Time(1, 999999999));
+    const rclcpp::Time d(rclcpp::Time(1000000000, 999999999));
     std::uint64_t pcl_stamp;
     pcl_conversions::toPCL(d, pcl_stamp);
-    EXPECT_EQ(pcl_stamp, 2000000);
+    EXPECT_EQ(pcl_stamp, 1000000001000000);
   }
 }
 


### PR DESCRIPTION
This also closes #514

The previous method of rounding ROS time using std::round(double) does no longer work if the timestamp is large enough that millisecond precision is lost due to floating point errors.